### PR TITLE
chore(state machine) : Add WinConditionEntity and connect to stateMac…

### DIFF
--- a/scenes/gameplay/world/level/i_level.gd
+++ b/scenes/gameplay/world/level/i_level.gd
@@ -1,7 +1,7 @@
 ## © [2024] A7 Studio. All rights reserved. Trademark.
 ## Base class for all game levels. Manages level state, resources, and map loading.
-extends Node2D
-class_name ILevel
+
+class_name ILevel extends Node2D
 
 ## Victory and defeat states
 signal stats_updated
@@ -14,6 +14,8 @@ static var current_level: ILevel = null
 @export var map_scene: PackedScene = null
 
 @export var win_condition: WinConditionEntity = null
+
+## Array of differents signal (if more needed)
 
 ## Current coin count for purchasing towers
 var coins: int = 75:
@@ -40,7 +42,7 @@ func _ready() -> void:
 		win_condition._build_state_machine()
 		win_condition._connect_signals()
 		if map.has_signal("victory"):
-			map.connect("victory", _on_victory)
+			SignalUtil.connects([ {SignalUtil.WHO: map, SignalUtil.WHAT: "victory", SignalUtil.TO: _on_victory}])
 	else:
 		Log.trace(Log.Level.ERROR, "ILevel.gd: map_scene is null. Cannot initialize map.")
 	emit_signal("level_ready", self)
@@ -71,7 +73,8 @@ func _set_health(new_value: int) -> void:
 func _on_wave_complete(last_wave: bool) -> void:
 	Log.trace(Log.Level.INFO, "Wave complete signal received. Last wave: %s" % last_wave)
 	win_condition._on_wave_complete(last_wave)
-	
+
+## Called to change the State to victoryState
 func _on_victory() -> void:
 	Log.trace(Log.Level.INFO, "Victory condition reached")
 	win_condition.state_machine.transition_to(WinConditionEntity.STATE_VICTORY)
@@ -83,9 +86,9 @@ func _load_map() -> void:
 	add_child(new_map)
 
 	Global.cursor.map_ref = map
-	
+
 	if new_map.has_signal("wave_complete"):
-		new_map.connect("wave_complete", Callable(self, "_on_wave_complete"))
+		SignalUtil.connects([ {SignalUtil.WHO: new_map, SignalUtil.WHAT: "wave_complete", SignalUtil.TO: _on_wave_complete}])
 		Log.trace(Log.Level.INFO, "Connected 'wave_complete' signal from map.")
 	else:
 		Log.trace(Log.Level.ERROR, "Map does not have 'wave_complete' signal.")

--- a/scenes/gameplay/world/level/i_level.gd
+++ b/scenes/gameplay/world/level/i_level.gd
@@ -38,9 +38,7 @@ func _ready() -> void:
 		add_child(new_map)
 		map = new_map
 		Log.trace(Log.Level.INFO, "ILevel.gd: Map instance created and added to the level")
-		win_condition = WinConditionEntity.new()
-		win_condition._build_state_machine()
-		win_condition._connect_signals()
+		win()
 		if map.has_signal("victory"):
 			SignalUtil.connects([ {SignalUtil.WHO: map, SignalUtil.WHAT: "victory", SignalUtil.TO: _on_victory}])
 	else:
@@ -57,6 +55,11 @@ func initialize(meta: LevelMetadata) -> void:
 ## Starts the next wave of enemies
 func start_new_wave() -> void:
 	pass
+	
+func win() -> void:
+	win_condition = WinConditionEntity.new()
+	win_condition._build_state_machine()
+	win_condition._connect_signals()
 
 # private
 ## Updates coin count and emits stats_updated signal

--- a/scenes/gameplay/world/level/i_level.gd
+++ b/scenes/gameplay/world/level/i_level.gd
@@ -1,18 +1,19 @@
 ## © [2024] A7 Studio. All rights reserved. Trademark.
-##
-## Base class for all game levels. Manages level state, resources and map loading.
-## @tutorial: See level_1.tscn for implementation example
-class_name ILevel
+## Base class for all game levels. Manages level state, resources, and map loading.
 extends Node2D
+class_name ILevel
 
-## Emitted when level stats (health/coins) are updated
+## Victory and defeat states
 signal stats_updated
+signal level_ready
 
 ## Reference to currently active level instance
 static var current_level: ILevel = null
 
 ## Scene containing the map layout and wave data
 @export var map_scene: PackedScene = null
+
+@export var win_condition: WinConditionEntity = null
 
 ## Current coin count for purchasing towers
 var coins: int = 75:
@@ -30,7 +31,19 @@ var metadata: LevelMetadata = null
 
 # core
 func _ready() -> void:
-	assert(map_scene != null, "map_scene must be set in the editor")
+	if map_scene != null:
+		var new_map = map_scene.instantiate()
+		add_child(new_map)
+		map = new_map
+		Log.trace(Log.Level.INFO, "ILevel.gd: Map instance created and added to the level")
+		win_condition = WinConditionEntity.new()
+		win_condition._build_state_machine()
+		win_condition._connect_signals()
+		if map.has_signal("victory"):
+			map.connect("victory", _on_victory)
+	else:
+		Log.trace(Log.Level.ERROR, "ILevel.gd: map_scene is null. Cannot initialize map.")
+	emit_signal("level_ready", self)
 
 # public
 ## Initializes the level with provided metadata
@@ -43,34 +56,36 @@ func initialize(meta: LevelMetadata) -> void:
 func start_new_wave() -> void:
 	pass
 
-## Called when player wins the level
-func win() -> void:
-	pass
-
-## Called when player loses the level
-func loose() -> void:
-	pass
-
 # private
-## Loads and initializes the map scene
-func _load_map() -> void:
-	Log.trace(Log.Level.INFO, "Loading map ...")
-	if not map_scene:
-		Log.trace(Log.Level.ERROR, "An IMap must be provided to create a level!")
-		return
-
-	var new_map: IMap = map_scene.instantiate()
-	add_child(new_map)
-	map = new_map
-
-	Global.cursor.map_ref = map
-
 ## Updates coin count and emits stats_updated signal
 func _set_coins(new_value: int) -> void:
 	coins = new_value
 	stats_updated.emit()
 
-## Updates health points and emits stats_updated signal
+## Updates health points 
 func _set_health(new_value: int) -> void:
 	health = new_value
 	stats_updated.emit()
+	
+## Called when a wave ends
+func _on_wave_complete(last_wave: bool) -> void:
+	Log.trace(Log.Level.INFO, "Wave complete signal received. Last wave: %s" % last_wave)
+	win_condition._on_wave_complete(last_wave)
+	
+func _on_victory() -> void:
+	Log.trace(Log.Level.INFO, "Victory condition reached")
+	win_condition.state_machine.transition_to(WinConditionEntity.STATE_VICTORY)
+
+
+## Loads and initializes the map scene
+func _load_map() -> void:
+	var new_map: Node = map_scene.instantiate()
+	add_child(new_map)
+
+	Global.cursor.map_ref = map
+	
+	if new_map.has_signal("wave_complete"):
+		new_map.connect("wave_complete", Callable(self, "_on_wave_complete"))
+		Log.trace(Log.Level.INFO, "Connected 'wave_complete' signal from map.")
+	else:
+		Log.trace(Log.Level.ERROR, "Map does not have 'wave_complete' signal.")

--- a/scenes/gameplay/world/level/levels/level_1.tscn
+++ b/scenes/gameplay/world/level/levels/level_1.tscn
@@ -2,6 +2,11 @@
 
 [ext_resource type="PackedScene" uid="uid://df2663whp8p7v" path="res://scenes/gameplay/world/level/i_level.tscn" id="1_ymvm1"]
 [ext_resource type="PackedScene" uid="uid://oc6r5kow8d7i" path="res://scenes/gameplay/world/map/maps/map_1.tscn" id="2_kysqm"]
+[ext_resource type="Script" path="res://scenes/gameplay/world/win_condition/win_condition.gd" id="3_61uh2"]
 
 [node name="ILevel" instance=ExtResource("1_ymvm1")]
 map_scene = ExtResource("2_kysqm")
+
+[node name="WinConditionEntity" type="Node" parent="." index="1" node_paths=PackedStringArray("level")]
+script = ExtResource("3_61uh2")
+level = NodePath("..")

--- a/scenes/gameplay/world/map/i_map.gd
+++ b/scenes/gameplay/world/map/i_map.gd
@@ -49,7 +49,7 @@ func _start_wave(index: int) -> void:
 	if index == waves.size():
 		Log.trace(Log.Level.DEBUG, "You WIN !!!")
 		waves_timer.stop()
-		emit_signal("victory")
+		victory.emit()
 		return
 
 	waves[index].start_wave()

--- a/scenes/gameplay/world/map/i_map.gd
+++ b/scenes/gameplay/world/map/i_map.gd
@@ -5,11 +5,11 @@
 class_name IMap
 extends Node2D
 
-## Emitted when all waves are completed successfully
-signal win
+signal wave_complete(last_wave: bool)
+signal victory
 
-## Emitted when player loses the map
-signal loose
+## Returns true if all waves are completed
+@export var all_waves_completed: bool = false
 
 ## Reference to the TileMap node for map layout
 @export var tilemap: TileMap
@@ -26,6 +26,8 @@ var waves: Array[Wave] = []
 @onready var waves_timer: Timer = $WavesTimer
 @onready var popup_wave_spawner: PopupSpawner = $PopupWaveSpawner
 @onready var camera: Camera2D = $Camera2D
+
+@export var win_condition : WinConditionEntity = null;
 
 @onready var signals: Array[Dictionary] = [
 	{SignalUtil.WHO: waves_timer, SignalUtil.WHAT: "timeout", SignalUtil.TO: _on_waves_timer_timeout},
@@ -46,8 +48,8 @@ func _ready() -> void:
 func _start_wave(index: int) -> void:
 	if index == waves.size():
 		Log.trace(Log.Level.DEBUG, "You WIN !!!")
-		win.emit()
 		waves_timer.stop()
+		emit_signal("victory")
 		return
 
 	waves[index].start_wave()

--- a/scenes/gameplay/world/map/i_map.gd
+++ b/scenes/gameplay/world/map/i_map.gd
@@ -8,11 +8,14 @@ extends Node2D
 signal wave_complete(last_wave: bool)
 signal victory
 
-## Returns true if all waves are completed
-@export var all_waves_completed: bool = false
-
 ## Reference to the TileMap node for map layout
 @export var tilemap: TileMap
+
+## Returns true if all waves are completed
+var all_waves_completed: bool = false
+
+# Instance of win condition
+var win_condition : WinConditionEntity = null;
 
 ## Index of current active wave
 var current_wave: int = -1
@@ -26,8 +29,6 @@ var waves: Array[Wave] = []
 @onready var waves_timer: Timer = $WavesTimer
 @onready var popup_wave_spawner: PopupSpawner = $PopupWaveSpawner
 @onready var camera: Camera2D = $Camera2D
-
-@export var win_condition : WinConditionEntity = null;
 
 @onready var signals: Array[Dictionary] = [
 	{SignalUtil.WHO: waves_timer, SignalUtil.WHAT: "timeout", SignalUtil.TO: _on_waves_timer_timeout},

--- a/scenes/gameplay/world/wave/wave.gd
+++ b/scenes/gameplay/world/wave/wave.gd
@@ -24,6 +24,9 @@ signal wave_complete(last_wave: bool)
 ## WinConditionEntity with State Machine
 @export var win_condition: WinConditionEntity = null
 
+## Export of wave class
+@export var wave: Wave = null
+
 ## Delay in seconds before next wave starts
 @export_range(0.1, 10.0) var delay: float = 0.1
 
@@ -56,8 +59,6 @@ var paths: Array[Path2D] = []
 
 ## If all the waves are finished
 var all_waves_completed: bool = false
-
-@export var wave: Wave = null
 
 ## Timer to spawn enemies
 @onready var timer: Timer = $Timer

--- a/scenes/gameplay/world/wave/wave.gd
+++ b/scenes/gameplay/world/wave/wave.gd
@@ -12,13 +12,23 @@ signal wave_start
 ## [param delay] Time to wait before next wave
 signal wave_end(delay: float)
 
-## Modifiers applied to all enemies in group
-## e.g : [code]{"damage": +15}[/code]
+## Emitted when all waves are completed
+## [param last_wave] True if it is the final wave
+signal wave_complete(last_wave: bool)
+
+## Modifiers applied globally to all enemies in this wave
+## e.g : {"damage": +15}
 ## @experimental
 @export var global_modifiers: Dictionary = {}
 
+## WinConditionEntity with State Machine
+@export var win_condition: WinConditionEntity = null
+
 ## Delay in seconds before next wave starts
 @export_range(0.1, 10.0) var delay: float = 0.1
+
+## ActuelLevel
+var level: ILevel = null
 
 ## Index of current enemy being spawned
 var current_enemy: int = -1
@@ -44,6 +54,11 @@ var is_ready: bool = false
 ## Available paths for enemy movement
 var paths: Array[Path2D] = []
 
+## If all the waves are finished
+var all_waves_completed: bool = false
+
+@export var wave: Wave = null
+
 ## Timer to spawn enemies
 @onready var timer: Timer = $Timer
 
@@ -55,6 +70,7 @@ var paths: Array[Path2D] = []
 func _ready() -> void:
 	_load_groups()
 	SignalUtil.connects(signals)
+	Log.trace(Log.Level.INFO, "Wave instance added to level")
 
 func _process(_delta: float) -> void:
 	timer.set_paused(Global.paused)
@@ -64,11 +80,16 @@ func _process(_delta: float) -> void:
 func start_wave() -> void:
 	Log.trace(Log.Level.INFO, "{0} start".format([name]))
 	if not is_ready: return
+	current_enemy = -1
+	dead_enemies = 0
+	enemies_total_count = 0
+
+	for group in groups:
+		enemies_total_count += group.enemies.size()
 
 	wave_start.emit()
 	_start_next_group()
 
-## Sets available paths for enemy movement
 func set_paths(in_paths: Array[Path2D]) -> void:
 	paths = in_paths
 	is_ready = true
@@ -77,7 +98,6 @@ func set_paths(in_paths: Array[Path2D]) -> void:
 ## Starts spawning the next group of enemies
 func _start_next_group() -> void:
 	current_group += 1
-
 	if current_group >= groups.size():
 		# wait for last enemy to dies
 		return
@@ -88,7 +108,6 @@ func _start_next_group() -> void:
 	timer.wait_time = groups[current_group].in_delay
 	timer.start()
 
-## Loads enemy groups from child nodes
 func _load_groups() -> void:
 	var children: Array[Node] = get_children()
 
@@ -103,10 +122,9 @@ func _load_groups() -> void:
 # signals
 ## Called when timer expires to spawn next enemy
 func _on_timer_timeout() -> void:
-	if not is_ready: return
-
+	if not is_ready:
+		return
 	current_enemy += 1
-
 	if current_enemy >= enemies_to_spawn.size():
 		timer.stop()
 		await get_tree().create_timer(groups[current_group].out_delay).timeout
@@ -120,7 +138,7 @@ func _on_timer_timeout() -> void:
 ## Called when an enemy is defeated
 func _on_ienemy_die() -> void:
 	dead_enemies += 1
-
+	Log.trace(Log.Level.DEBUG, "Total: {0}/{1}".format([dead_enemies, enemies_total_count]))
 	if dead_enemies == enemies_total_count:
 		Log.trace(Log.Level.INFO, "%s end" % name)
 		wave_end.emit(delay)

--- a/scenes/gameplay/world/win_condition/win_condition.gd
+++ b/scenes/gameplay/world/win_condition/win_condition.gd
@@ -22,6 +22,8 @@ const STATE_LOSE: String = "StateLose"
 # Level reference
 @export var level: ILevel = null
 
+@export var win_condition: WinConditionEntity = null
+
 # State machine instance
 var state_machine: StateMachine
 
@@ -31,6 +33,7 @@ func _ready() -> void:
 func _setup() -> void:
 	_build_state_machine()
 	state_machine.toggle_initial_state()
+	_connect_signals()
 
 	if not level:
 		Log.trace(Log.Level.WARN, "Level reference is missing in WinConditionEntity. Waiting for initialization...")

--- a/scenes/gameplay/world/win_condition/win_condition.gd
+++ b/scenes/gameplay/world/win_condition/win_condition.gd
@@ -1,0 +1,157 @@
+## © [2024] A7 Studio. All rights reserved. Trademark.
+class_name WinConditionEntity
+extends Node
+
+## Class with all WinCondition State
+##
+## Manages game level states like configuring, start/end of wave & level,
+## victory, and loss. Uses StateMachine to handle transitions based on
+## level status and health. Connects to signal updates for stats and wave completion.
+##
+
+
+# Constants for state names
+const STATE_CONFIGURING: String = "StateConfiguring"
+const STATE_START_WAVE: String = "StateStartWave"
+const STATE_ONGOING_WAVE: String = "StateOngoingWave"
+const STATE_END_WAVE: String = "StateEndWave"
+const STATE_END_LEVEL: String = "StateEndLevel"
+const STATE_VICTORY: String = "StateVictory"
+const STATE_LOSE: String = "StateLose"
+
+# Level reference
+@export var level: ILevel = null
+
+# State machine instance
+var state_machine: StateMachine
+
+func _ready() -> void:
+	_setup()
+
+func _setup() -> void:
+	_build_state_machine()
+	state_machine.toggle_initial_state()
+
+	if not level:
+		Log.trace(Log.Level.WARN, "Level reference is missing in WinConditionEntity. Waiting for initialization...")
+		return
+
+	_connect_signals()
+	Log.trace(Log.Level.INFO, "WinConditionEntity is ready.")
+
+func _process(delta: float) -> void:
+	state_machine.handle_current_state([delta])
+
+# Setup the state machine
+func _build_state_machine() -> void:
+	var builder: StateMachineBuilder = StateMachineBuilder.new()
+
+	builder.build_initial_state(STATE_CONFIGURING, _on_configuring_state)
+	builder.build_state(STATE_START_WAVE, _on_start_wave_state)
+	builder.build_state(STATE_ONGOING_WAVE, _on_ongoing_wave_state)
+	builder.build_state(STATE_END_WAVE, _on_end_wave_state)
+	builder.build_state(STATE_VICTORY, _on_victory_state)
+	builder.build_state(STATE_LOSE, _on_lose_state)
+	builder.build_state(STATE_END_LEVEL, _on_end_level_state)
+
+	builder.build_transition(STATE_CONFIGURING, STATE_START_WAVE, _on_start_wave_state)
+	builder.build_transition(STATE_START_WAVE, STATE_ONGOING_WAVE)
+	builder.build_transition(STATE_ONGOING_WAVE, STATE_END_WAVE, _on_end_wave_state)
+	builder.build_transition(STATE_END_WAVE, STATE_START_WAVE, _on_start_wave_state)
+	builder.build_transition(STATE_ONGOING_WAVE, STATE_LOSE, _on_lose_state)
+	builder.build_transition(STATE_END_WAVE, STATE_LOSE)
+	builder.build_transition(STATE_CONFIGURING, STATE_VICTORY, _on_victory_state)
+
+	state_machine = builder.build()
+
+# Signal connections
+func _connect_signals() -> void:
+	if not level:
+		Log.trace(Log.Level.ERROR, "Cannot connect signals. Level reference is null.")
+		return
+
+	SignalUtil.connects([
+		{SignalUtil.WHO: level, SignalUtil.WHAT: "stats_updated", SignalUtil.TO: Callable(self, "_evaluate_conditions")}
+	])
+
+	if level.map:
+		SignalUtil.connects([
+			{SignalUtil.WHO: level.map, SignalUtil.WHAT: "wave_complete", SignalUtil.TO: Callable(self, "_on_wave_complete")}
+		])
+	else:
+		Log.trace(Log.Level.ERROR, "Cannot connect 'wave_complete' signal. Level map is null.")
+
+# State callbacks
+func _on_configuring_state(_args: Array) -> bool:
+	Log.trace(Log.Level.INFO, "Configuring level...")
+	state_machine.transition_to(STATE_START_WAVE)
+	return true
+
+#Called when the wave is started
+func _on_start_wave_state() -> void:
+	Log.trace(Log.Level.INFO, "Starting wave...")
+	if level and level.map:
+		state_machine.transition_to(STATE_ONGOING_WAVE)
+	else:
+		Log.trace(Log.Level.ERROR, "Level or map is not properly set. Cannot start wave.")
+
+func _on_ongoing_wave_state(_args : Array) -> bool:
+	return true
+
+#Called when a wave is ended
+func _on_end_wave_state() -> void:
+	Log.trace(Log.Level.INFO, "Wave ended.")
+	if level.health > 0 and level.map.all_waves_completed:
+		state_machine.transition_to(STATE_VICTORY)
+	else:
+		state_machine.transition_to(STATE_START_WAVE)
+
+# Called when all waves are finished
+func _on_end_level_state() -> void:
+	Log.trace(Log.Level.INFO, "End of level.")
+	if level.health > 0 and level.map.all_waves_completed:
+		state_machine.transition_to(STATE_VICTORY)
+
+func _on_victory_state() -> void:
+	Log.trace(Log.Level.INFO, "Victory! All waves completed.")
+
+func _on_lose_state() -> void:
+	Log.trace(Log.Level.INFO, "Defeat! Health has reached zero.")
+	_pause_game()
+
+# Evaluate win/lose conditions
+func _evaluate_conditions() -> void:
+	if not state_machine:
+		Log.trace(Log.Level.ERROR, "State machine reference is null.")
+		return
+
+	var current_state: State = state_machine.get_current_state()
+	Log.trace(Log.Level.DEBUG, "Current state: %s" % current_state)
+
+	# Prevent redundant transitions
+	if current_state in [STATE_VICTORY, STATE_LOSE]:
+		return
+
+	if level.health <= 0:
+		if current_state.name != STATE_CONFIGURING:
+			if state_machine.transition_to(STATE_LOSE):
+				Log.trace(Log.Level.INFO, "Successfully transitioned to StateLose.")
+			else:
+				Log.trace(Log.Level.ERROR, "Failed to transition to StateLose.")
+	elif level.map and level.map.all_waves_completed and level.health > 0:
+		state_machine.transition_to(STATE_VICTORY)
+
+# Wave complete signal handler
+func _on_wave_complete(last_wave: bool) -> void:
+	Log.trace(Log.Level.DEBUG, "Transitioning to next wave state.")
+	if last_wave:
+		state_machine.transition_to(STATE_END_WAVE)
+	else:
+		state_machine.transition_to(STATE_START_WAVE)
+		level.map._start_wave
+
+
+# Pause the game
+func _pause_game() -> void:
+	get_tree().paused = true
+	Log.trace(Log.Level.INFO, "Game paused.")

--- a/scripts/state_machine/state_machine.gd
+++ b/scripts/state_machine/state_machine.gd
@@ -99,6 +99,24 @@ func _find_transition(from: State, to: State) -> Transition:
 			return tra
 	return null
 
+## Method to handle state transitions
+func transition_to(state_id: String) -> bool:
+	if not states.has(state_id):
+		Log.trace(Log.Level.ERROR, "%s : Unknown state id: '%s'" % [name, state_id])
+		return false
+	var next_state             = states.get(state_id)
+	var transition: Transition = _find_transition(current_state, next_state)
+
+	if transition:
+		current_state = next_state
+		transition.handle() #
+		Log.trace(Log.Level.INFO, "%s : Transitioned to state %s" % [name, current_state])
+		emit_signal("state_changed", current_state)
+		return true
+	else:
+		Log.trace(Log.Level.ERROR, "%s : Invalid transition from %s to %s" % [name, current_state, state_id])
+		return false
+
 
 # signal
 

--- a/scripts/state_machine/state_machine.gd
+++ b/scripts/state_machine/state_machine.gd
@@ -104,7 +104,7 @@ func transition_to(state_id: String) -> bool:
 	if not states.has(state_id):
 		Log.trace(Log.Level.ERROR, "%s : Unknown state id: '%s'" % [name, state_id])
 		return false
-	var next_state             = states.get(state_id)
+	var next_state: State = states.get(state_id)
 	var transition: Transition = _find_transition(current_state, next_state)
 
 	if transition:

--- a/scripts/state_machine/state_machine_builder.gd
+++ b/scripts/state_machine/state_machine_builder.gd
@@ -45,8 +45,8 @@ func build_initial_state(state_id: String, state_callback: Callable) -> StateMac
 ## [param tr_id_to] : The ID of the state we're transitioning to
 ## [param new_callback] : The function to call when the transition is executed
 func build_transition(tr_id_from: String, tr_id_to: String, new_callback: Callable = func(): pass) -> StateMachineBuilder:
-	var transition := TransitionFactory.create(
-		_state_machine.states.get(tr_id_from), 
+	var transition: Transition = TransitionFactory.create(
+		_state_machine.states.get(tr_id_from),
 		_state_machine.states.get(tr_id_to),
 		new_callback
 	)

--- a/scripts/utilities/signals/signal_util.gd
+++ b/scripts/utilities/signals/signal_util.gd
@@ -26,30 +26,30 @@ const TO: String = "to"
 ##               Each dictionary must contain three keys: WHO (node emitting the signal),
 ##               WHAT (signal name), and TO (callback method).
 static func connects(signals: Array[Dictionary]) -> void:
-    for signal_info in signals:
-        assert(
-            WHO in signal_info.keys(),
-            "Signal dictionary must contain a '{0}' key".format([WHO])
-        )
-        assert(
-            WHAT in signal_info.keys(),
-            "Signal dictionary must contain a '{0}' key".format([WHAT])
-        )
-        assert(
-            TO in signal_info.keys(),
-            "Signal dictionary must contain a '{0}' key".format([TO])
-        )
+	for signal_info in signals:
+		assert(
+			WHO in signal_info.keys(),
+			"Signal dictionary must contain a '{0}' key".format([WHO])
+		)
+		assert(
+			WHAT in signal_info.keys(),
+			"Signal dictionary must contain a '{0}' key".format([WHAT])
+		)
+		assert(
+			TO in signal_info.keys(),
+			"Signal dictionary must contain a '{0}' key".format([TO])
+		)
 
-        signal_info[WHO].connect(signal_info[WHAT], signal_info[TO])
+		signal_info[WHO].connect(signal_info[WHAT], signal_info[TO])
 
-        Log.trace(
-            Log.Level.DEBUG,
-            "Connecting signal {node}.{signal} to {callback}".format({
-                "node": signal_info[WHO],
-                "signal": signal_info[WHAT],
-                "callback": signal_info[TO]
-            })
-        )
+		Log.trace(
+			Log.Level.DEBUG,
+			"Connecting signal {node}.{signal} to {callback}".format({
+				"node": signal_info[WHO],
+				"signal": signal_info[WHAT],
+				"callback": signal_info[TO]
+			})
+		)
 
 # private
 


### PR DESCRIPTION
Connexion différents états state machine pour les conditions de victoire 
Ajouts de différents signaux
Actuellement la défaite est juste préparé pour mettre le jeu en pause lorsque les health point atteignent 0 
et la victoire si toutes les conditions necessaires sont atteintes

En attentes de recevoir les nouvelles conditions pour les différentes étoiles par niveau (ex : sans perdre de pts de vie, minimumde tour etc...)