### PR TITLE
Set tower placement to only check the tile of the tower and not neighbors.

### DIFF
--- a/scenes/gameplay/entities/tower_placement/tower_placement.gd
+++ b/scenes/gameplay/entities/tower_placement/tower_placement.gd
@@ -31,13 +31,13 @@ func _get_initial_tower_position() -> Vector2:
 	if camera:
 		var world_position := camera.get_screen_center_position()
 		return world_position
-	
+
 	# Fallback: if no camera, get the center of the map
 	if tm_ref:
 		var map_rect := tm_ref.get_used_rect()
 		var map_center := map_rect.position + (map_rect.size / 2)
 		return tm_ref.map_to_local(map_center)
-	
+
 	# Ultimate fallback
 	return Vector2.ZERO
 
@@ -149,7 +149,7 @@ func _state_build(tower: ITower = null) -> void:
 		# Get the initial position before creating the tower
 		var initial_pos := _get_initial_tower_position()
 		_set_cursor_position(initial_pos)
-		
+
 		_tower = tower.duplicate()
 		_tower.state = ITower.TowerState.BUILDING
 		_tower.position = cursor.position - Vector2(0, 16)
@@ -220,18 +220,10 @@ func _build() -> void:
 	map_ref.add_child(new_tower)
 	tower_count += 1
 
-
 	ILevel.current_level.coins -= _tower.cost
 
-	var tm_pos: Array[Vector2i] = [
-		tm_ref.local_to_map(new_tower.position),
-		tm_ref.local_to_map(new_tower.position) - UP_OFFSET,
-		tm_ref.local_to_map(new_tower.position) - RIGHT_OFFSET,
-		tm_ref.local_to_map(new_tower.position) - LEFT_OFFSET,
-	]
-
-	for p in tm_pos:
-		_invalid_cells.append(p)
+	var tm_pos: Vector2i = tm_ref.local_to_map(new_tower.position)
+	_invalid_cells.append(tm_pos)
 
 	_cancel_build()
 	_is_move_tower_available = true
@@ -240,19 +232,13 @@ func _is_buildable(pos: Vector2) -> bool:
 	if ILevel.current_level.coins < _tower.cost:
 		return false
 
-	var tm_pos: Array[Vector2i] = [
-		tm_ref.local_to_map(pos),
-		tm_ref.local_to_map(pos) - UP_OFFSET,
-		tm_ref.local_to_map(pos) - RIGHT_OFFSET,
-		tm_ref.local_to_map(pos) - LEFT_OFFSET,
-	]
+	var tm_pos: Vector2i = tm_ref.local_to_map(pos)
 
-	for p in tm_pos:
-		if not tm_ref.get_cell_atlas_coords(0, p) in VALID_TILES or p in _invalid_cells:
-			return false
+	if not tm_ref.get_cell_atlas_coords(0, tm_pos) in VALID_TILES or tm_pos in _invalid_cells:
+		return false
 
-		if tm_ref.get_cell_atlas_coords(1, p) != Vector2i(-1, -1):
-			return false
+	if tm_ref.get_cell_atlas_coords(1, tm_pos) != Vector2i(-1, -1):
+		return false
 
 	return true
 


### PR DESCRIPTION
This pull request changes that the check for valid tower placement should now only check the current tile and not 4 tiles. As now the tiles are now smaller, this is a required change.