### PR TITLE
Mise en gris du bouton d'amélioration si fond insuffisant

### DIFF
--- a/scenes/gameplay/entities/bullet/fire_arrow.tscn
+++ b/scenes/gameplay/entities/bullet/fire_arrow.tscn
@@ -69,8 +69,8 @@ shape = SubResource("CircleShape2D_a2b3u")
 material = SubResource("CanvasItemMaterial_tc12e")
 emitting = false
 amount = 30
-process_material = SubResource("ParticleProcessMaterial_aqjwg")
 lifetime = 1.5
+process_material = SubResource("ParticleProcessMaterial_aqjwg")
 
 [node name="BurnAreaSprite" type="Sprite2D" parent="." index="5"]
 visible = false

--- a/scenes/ui/menus/tower_upgrade/tower_upgrade_menu.gd
+++ b/scenes/ui/menus/tower_upgrade/tower_upgrade_menu.gd
@@ -2,14 +2,14 @@ class_name TowerUpgradeMenu
 extends Control
 
 var sell_price: int
-var upgrade_price: int
 var tower: ITower
+var upgrade_price: int
 
+@onready var close_button: TextureButton = $VBoxContainer/CloseAspectRatioContainer/CloseTextureButton
 @onready var sell_button: TextureButton = $VBoxContainer/HBoxContainer/SellAspectRatioContainer/SellTextureButton
 @onready var sell_label: Label = $VBoxContainer/HBoxContainer/SellAspectRatioContainer/SellLabel
 @onready var upgrade_button: TextureButton = $VBoxContainer/HBoxContainer/UpgradeAspectRatioContainer/UpgradeTextureButton
 @onready var upgrade_label: Label = $VBoxContainer/HBoxContainer/UpgradeAspectRatioContainer/UpgradeLabel
-@onready var close_button: TextureButton = $VBoxContainer/CloseAspectRatioContainer/CloseTextureButton
 
 @onready var signals: Array[Dictionary] = [
 	{SignalUtil.WHO: close_button, SignalUtil.WHAT: "pressed", SignalUtil.TO: _on_close_button_pressed},
@@ -32,18 +32,49 @@ func _ready() -> void:
 		# Change upgrade button to gray rbg #525252
 		upgrade_button.modulate = Color(0.325, 0.325, 0.325)  # Gray color
 		upgrade_label.text = "MAX"
+	
+	# Connect to level stats updates to refresh button state when coins change
+	if ILevel.current_level:
+		ILevel.current_level.stats_updated.connect(_on_level_stats_updated)
+	
+	# Update button state initially
+	_update_upgrade_button_state()
+	
 	SignalUtil.connects(signals)
 
 
+## Updates the visual state of the upgrade button based on available coins
+func _update_upgrade_button_state() -> void:
+	# Only check money if there's an upgrade available
+	if tower.available_upgrade.is_empty():
+		return
+	
+	var can_afford: bool = ILevel.current_level.coins >= upgrade_price
+	
+	if can_afford:
+		upgrade_button.modulate = Color(1.0, 1.0, 1.0)  # White (enabled)
+		upgrade_button.disabled = false
+	else:
+		upgrade_button.modulate = Color(0.325, 0.325, 0.325)  # Gray (disabled)
+		upgrade_button.disabled = true
+
+
 func _on_close_button_pressed():
+	# Disconnect from level stats when closing
+	if ILevel.current_level and ILevel.current_level.stats_updated.is_connected(_on_level_stats_updated):
+		ILevel.current_level.stats_updated.disconnect(_on_level_stats_updated)
+	queue_free()
+
+
+func _on_level_stats_updated() -> void:
+	_update_upgrade_button_state()
+
+
+func _on_sell_button_pressed():
+	tower.sell_tower()
 	queue_free()
 
 
 func _on_upgrade_button_pressed():
 	tower.start_upgrade(tower.available_upgrade[0])
 	_on_close_button_pressed()
-
-
-func _on_sell_button_pressed():
-	tower.sell_tower()
-	queue_free()


### PR DESCRIPTION
**Implémentation de la mise en gris du bouton d'amélioration quand fonds insuffisants**

Ajout d'un retour visuel en temps réel au bouton d'amélioration des tours en se connectant au signal `stats_updated` du niveau. Le bouton se grise désormais dynamiquement et se désactive quand le joueur n'a pas assez de pièces, reproduisant le comportement des boutons de construction de tours. Ajout de la fonction `_update_upgrade_button_state()` qui vérifie la capacité financière et met à jour l'apparence du bouton en conséquence, avec connexion/déconnexion propre du signal pour éviter les fuites mémoire.