### PR TITLE
Ajout de la range de la tour dans son menu

### DIFF
--- a/scenes/gameplay/entities/bullet/fire_arrow.tscn
+++ b/scenes/gameplay/entities/bullet/fire_arrow.tscn
@@ -69,8 +69,8 @@ shape = SubResource("CircleShape2D_a2b3u")
 material = SubResource("CanvasItemMaterial_tc12e")
 emitting = false
 amount = 30
-process_material = SubResource("ParticleProcessMaterial_aqjwg")
 lifetime = 1.5
+process_material = SubResource("ParticleProcessMaterial_aqjwg")
 
 [node name="BurnAreaSprite" type="Sprite2D" parent="." index="5"]
 visible = false

--- a/scenes/gameplay/entities/tower/i_tower.gd
+++ b/scenes/gameplay/entities/tower/i_tower.gd
@@ -125,6 +125,7 @@ func _process(_delta: float) -> void:
 
 	if state == TowerState.BUILDING:
 		_update_z_index()
+		# Allow range display even during building
 		return
 
 	if fire_rate_timer.is_stopped():
@@ -251,6 +252,19 @@ func sell_tower() -> void:
 	queue_free()
 
 # Private methods
+## Animates the range display based on the selected state
+func _animate_range_display() -> void:
+	var target_scale := Vector2(1, 1) if selected else Vector2(0, 0)
+	polygon_2d.visible = selected
+	var size: float = 0
+	while size < 1:
+		polygon_2d.scale = lerp(polygon_2d.scale, target_scale, size)
+		await get_tree().create_timer(0.01).timeout
+		size += 0.1
+
+	if selected:
+		_color_variation()
+
 func _apply_tower_stat_changes(upgrade: IUpgrade) -> void:
 	for stat in upgrade.tower_stats.keys():
 		if self.get(stat):
@@ -426,6 +440,11 @@ func _on_timer_timeout() -> void:
 
 func _on_tower_pressed() -> void:
 	Log.trace(Log.Level.INFO, "Tower Pressed")
+
+	# Toggle range display
+	selected = not selected
+	_animate_range_display()
+
 	if self.find_child("TowerUpgrade") != null:
 		Log.trace(Log.Level.WARN, "Tower upgrade menu already exists")
 		return

--- a/scenes/gameplay/entities/tower_placement/tower_placement.gd
+++ b/scenes/gameplay/entities/tower_placement/tower_placement.gd
@@ -180,9 +180,8 @@ func _state_build(tower: ITower = null) -> void:
 	_tower.modulate = COLOR_OK if is_buildable else COLOR_KO
 	_update_place_button_state(is_buildable)
 	
-	# Disable the tower button and hover box so it can't be interacted with during placement
-	if _tower.button:
-		_tower.button.disabled = true
+	# Allow the tower button to work during placement for range preview
+	# Disable only the hover box to prevent interference
 	if _tower.hover_box and _tower.hover_box.get_parent():
 		var hover_area: Area2D = _tower.hover_box.get_parent()
 		hover_area.monitoring = false


### PR DESCRIPTION
## Affichage de la portée des tours

Ajout d'un système d'affichage de la portée des tours cliquable :
- **Clic sur une tour placée** : Affiche/masque la portée avec une animation de scale et un effet de pulsation colorée
- **Prévisualisation en construction** : La portée peut également être affichée pendant le placement d'une tour en cliquant dessus, permettant de mieux évaluer la zone d'effet avant de confirmer la construction
- Réutilisation des animations existantes du système de survol pour garantir une cohérence visuelle