### PR TITLE
Stats centralisées dans un json et autoload pour remplacer les stats dans les scènes

### DIFF
--- a/assets/resources/configs/stats.json
+++ b/assets/resources/configs/stats.json
@@ -1,0 +1,170 @@
+{
+  "towers": {
+    "bat_01": {
+      "scene": "res://scenes/gameplay/entities/tower/towers/bat_01.tscn",
+      "base": {
+        "cost": 50,
+        "fire_rate": 1.5,
+        "shoot_range": 100.0,
+        "bullet_stats": {
+          "aoe_duration": 0.0,
+          "aoe_range": 0.0,
+          "aoe_tick": 0.0,
+          "damage": 0.0,
+          "damage_multiplier": 0.0,
+          "dot_damage": 0.0,
+          "piercing": 0.0,
+          "piercing_reduction": 0.0,
+          "speed": 0.0
+        }
+      },
+      "upgrades": ["bat_01_02"]
+    },
+    "bat_02": {
+      "scene": "res://scenes/gameplay/entities/tower/towers/bat_02.tscn",
+      "base": {
+        "cost": 50,
+        "fire_rate": 1.5,
+        "shoot_range": 150.0,
+        "bullet_stats": {
+          "aoe_duration": 0.0,
+          "aoe_range": 0.0,
+          "aoe_tick": 0.0,
+          "damage": 0.0,
+          "damage_multiplier": 0.0,
+          "dot_damage": 0.0,
+          "piercing": 0.0,
+          "piercing_reduction": 0.0,
+          "speed": 0.0
+        }
+      },
+      "upgrades": ["bat_02_02"]
+    }
+  },
+  "upgrades": {
+    "bat_01_02": {
+      "price": 75,
+      "tower_stats": {
+        "level": 1,
+        "shoot_range": 0.0,
+        "fire_rate": 0.0,
+        "projectile_count": 0,
+        "spread_angle": 0.0
+      },
+      "bullet_stats": {
+        "damage": 2.0,
+        "speed": 0.0,
+        "pierce_count": 0.0,
+        "pierce_reduction": 0.0,
+        "aoe_range": 0.0
+      },
+      "next": ["bat_01_03"]
+    },
+    "bat_01_03": {
+      "price": null,
+      "tower_stats": {},
+      "bullet_stats": {},
+      "next": []
+    },
+    "bat_01_b_04": {
+      "price": null,
+      "tower_stats": {
+        "level": 1,
+        "shoot_range": 0.0,
+        "fire_rate": 1.0,
+        "projectile_count": 1,
+        "spread_angle": 10.0
+      },
+      "bullet_stats": {
+        "damage": -2.0
+      },
+      "next": ["bat_01_b_05"]
+    },
+    "bat_01_b_05": {
+      "price": null,
+      "tower_stats": {},
+      "bullet_stats": {},
+      "next": []
+    },
+    "bat_02_02": {
+      "price": null,
+      "tower_stats": {},
+      "bullet_stats": {},
+      "next": ["bat_02_03"]
+    },
+    "bat_02_03": {
+      "price": null,
+      "tower_stats": {},
+      "bullet_stats": {},
+      "next": ["bat_02_a_04", "bat_02_b_04"]
+    },
+    "bat_02_a_04": {
+      "price": null,
+      "tower_stats": {},
+      "bullet_stats": {},
+      "next": []
+    },
+    "bat_02_b_04": {
+      "price": null,
+      "tower_stats": {
+        "level": 1,
+        "shoot_range": 0.0,
+        "fire_rate": 0.0,
+        "projectile_count": 0,
+        "spread_angle": 0.0
+      },
+      "bullet_stats": {
+        "aoe_range": 20.0,
+        "burn_damage_base": 0.0,
+        "burn_duration": 0.0,
+        "damage": 0.0,
+        "pierce_count": 0.0,
+        "pierce_reduction": 0.0,
+        "speed": 0.0
+      },
+      "next": ["bat_02_b_05"]
+    },
+    "bat_02_b_05": {
+      "price": null,
+      "tower_stats": {},
+      "bullet_stats": {},
+      "next": []
+    }
+  },
+  "enemies": {
+    "default_zombie": {
+      "scene": "res://scenes/gameplay/entities/enemy/enemies/ene.01.tscn",
+      "max_health": 20.0,
+      "speed": 45.0,
+      "reward": 10
+    },
+    "damage_zombie": {
+      "scene": "res://scenes/gameplay/entities/enemy/enemies/ene.02.tscn",
+      "max_health": 100.0,
+      "speed": 30.0,
+      "reward": 10
+    },
+    "rat": {
+      "scene": "res://scenes/gameplay/entities/enemy/enemies/ene.03.tscn",
+      "max_health": 10.0,
+      "speed": 100.0,
+      "reward": 10
+    },
+    "big_daddy": {
+      "scene": "res://scenes/gameplay/entities/enemy/enemies/big_daddy.tscn",
+      "max_health": null,
+      "speed": null,
+      "reward": 10,
+      "extra": {
+        "shoot_range": 150.0,
+        "fire_rate": 0.5,
+        "tower_disable_duration": 3.0,
+        "pre_attack_delay": 1.0,
+        "attack_duration": 1.0,
+        "post_attack_delay": 1.0,
+        "attack_cooldown": 5.0
+      }
+    }
+  }
+}
+

--- a/assets/resources/configs/stats.json
+++ b/assets/resources/configs/stats.json
@@ -43,6 +43,7 @@
   },
   "upgrades": {
     "bat_01_02": {
+      "scene": "res://scenes/gameplay/entities/upgrade/bat_01/bat_01_02.tscn",
       "price": 75,
       "tower_stats": {
         "level": 1,
@@ -61,12 +62,14 @@
       "next": ["bat_01_03"]
     },
     "bat_01_03": {
+      "scene": "res://scenes/gameplay/entities/upgrade/bat_01/bat_01_03.tscn",
       "price": null,
       "tower_stats": {},
       "bullet_stats": {},
       "next": []
     },
     "bat_01_b_04": {
+      "scene": "res://scenes/gameplay/entities/upgrade/bat_01/bat_01_b_04.tscn",
       "price": null,
       "tower_stats": {
         "level": 1,
@@ -81,30 +84,35 @@
       "next": ["bat_01_b_05"]
     },
     "bat_01_b_05": {
+      "scene": "res://scenes/gameplay/entities/upgrade/bat_01/bat_01_b_05.tscn",
       "price": null,
       "tower_stats": {},
       "bullet_stats": {},
       "next": []
     },
     "bat_02_02": {
+      "scene": "res://scenes/gameplay/entities/upgrade/bat_02/bat_02_02.tscn",
       "price": null,
       "tower_stats": {},
       "bullet_stats": {},
       "next": ["bat_02_03"]
     },
     "bat_02_03": {
+      "scene": "res://scenes/gameplay/entities/upgrade/bat_02/bat_02_03.tscn",
       "price": null,
       "tower_stats": {},
       "bullet_stats": {},
       "next": ["bat_02_a_04", "bat_02_b_04"]
     },
     "bat_02_a_04": {
+      "scene": "res://scenes/gameplay/entities/upgrade/bat_02/bat_02_a_04.tscn",
       "price": null,
       "tower_stats": {},
       "bullet_stats": {},
       "next": []
     },
     "bat_02_b_04": {
+      "scene": "res://scenes/gameplay/entities/upgrade/bat_02/bat_02_b_04.tscn",
       "price": null,
       "tower_stats": {
         "level": 1,
@@ -125,6 +133,7 @@
       "next": ["bat_02_b_05"]
     },
     "bat_02_b_05": {
+      "scene": "res://scenes/gameplay/entities/upgrade/bat_02/bat_02_b_05.tscn",
       "price": null,
       "tower_stats": {},
       "bullet_stats": {},

--- a/assets/resources/configs/stats.json
+++ b/assets/resources/configs/stats.json
@@ -63,14 +63,26 @@
     },
     "bat_01_03": {
       "scene": "res://scenes/gameplay/entities/upgrade/bat_01/bat_01_03.tscn",
-      "price": null,
-      "tower_stats": {},
-      "bullet_stats": {},
-      "next": []
+      "price": 0,
+      "tower_stats": {
+        "level": 1,
+        "shoot_range": 0.0,
+        "fire_rate": 0.0,
+        "projectile_count": 0,
+        "spread_angle": 0.0
+      },
+      "bullet_stats": {
+        "damage": 2.0,
+        "speed": 0.0,
+        "pierce_count": 0.0,
+        "pierce_reduction": 0.0,
+        "aoe_range": 0.0
+      },
+      "next": ["bat_01_a_04", "bat_01_b_04"]
     },
     "bat_01_b_04": {
       "scene": "res://scenes/gameplay/entities/upgrade/bat_01/bat_01_b_04.tscn",
-      "price": null,
+      "price": 0,
       "tower_stats": {
         "level": 1,
         "shoot_range": 0.0,
@@ -85,35 +97,60 @@
     },
     "bat_01_b_05": {
       "scene": "res://scenes/gameplay/entities/upgrade/bat_01/bat_01_b_05.tscn",
-      "price": null,
-      "tower_stats": {},
+      "price": 0,
+      "tower_stats": {
+        "fire_rate": 0.0,
+        "level": 1,
+        "projectile_count": 1,
+        "shoot_range": 0.0,
+        "spread_angle": 20.0
+      },
       "bullet_stats": {},
       "next": []
     },
     "bat_02_02": {
       "scene": "res://scenes/gameplay/entities/upgrade/bat_02/bat_02_02.tscn",
-      "price": null,
-      "tower_stats": {},
+      "price": 0,
+      "tower_stats": {
+        "fire_rate": 0.0,
+        "level": 1,
+        "projectile_count": 0,
+        "shoot_range": 0.0,
+        "spread_angle": 0.0
+      },
       "bullet_stats": {},
       "next": ["bat_02_03"]
     },
     "bat_02_03": {
       "scene": "res://scenes/gameplay/entities/upgrade/bat_02/bat_02_03.tscn",
-      "price": null,
-      "tower_stats": {},
+      "price": 0,
+      "tower_stats": {
+        "fire_rate": 0.0,
+        "level": 1,
+        "projectile_count": 0,
+        "shoot_range": 0.0,
+        "spread_angle": 0.0
+      },
       "bullet_stats": {},
       "next": ["bat_02_a_04", "bat_02_b_04"]
     },
     "bat_02_a_04": {
       "scene": "res://scenes/gameplay/entities/upgrade/bat_02/bat_02_a_04.tscn",
-      "price": null,
-      "tower_stats": {},
+      "price": 0,
+      "tower_stats": {
+        "fire_rate": 0.0,
+        "level": 1,
+        "projectile_count": 0,
+        "shoot_range": 0.0,
+        "spread_angle": 0.0
+      },
       "bullet_stats": {},
+      "bullet": "res://scenes/gameplay/entities/bullet/fire_arrow.tscn",
       "next": []
     },
     "bat_02_b_04": {
       "scene": "res://scenes/gameplay/entities/upgrade/bat_02/bat_02_b_04.tscn",
-      "price": null,
+      "price": 0,
       "tower_stats": {
         "level": 1,
         "shoot_range": 0.0,
@@ -134,9 +171,23 @@
     },
     "bat_02_b_05": {
       "scene": "res://scenes/gameplay/entities/upgrade/bat_02/bat_02_b_05.tscn",
-      "price": null,
-      "tower_stats": {},
-      "bullet_stats": {},
+      "price": 0,
+      "tower_stats": {
+        "fire_rate": 0.0,
+        "level": 1,
+        "projectile_count": 0,
+        "shoot_range": 0.0,
+        "spread_angle": 0.0
+      },
+      "bullet_stats": {
+        "aoe_range": 20.0,
+        "burn_damage_base": 0.0,
+        "burn_duration": 0.0,
+        "damage": 0.0,
+        "pierce_count": 0.0,
+        "pierce_reduction": 0.0,
+        "speed": 0.0
+      },
       "next": []
     }
   },
@@ -161,12 +212,12 @@
     },
     "big_daddy": {
       "scene": "res://scenes/gameplay/entities/enemy/enemies/big_daddy.tscn",
-      "max_health": null,
-      "speed": null,
+      "max_health": 1000.0,
+      "speed": 20.0,
       "reward": 10,
       "extra": {
-        "shoot_range": 150.0,
-        "fire_rate": 0.5,
+        "shoot_range": 100.0,
+        "fire_rate": 100.0,
         "tower_disable_duration": 3.0,
         "pre_attack_delay": 1.0,
         "attack_duration": 1.0,

--- a/assets/resources/configs/stats.json
+++ b/assets/resources/configs/stats.json
@@ -6,6 +6,8 @@
         "cost": 50,
         "fire_rate": 1.5,
         "shoot_range": 100.0,
+        "projectile_count": 1,
+        "spread_angle": 15.0,
         "bullet_stats": {
           "aoe_duration": 0.0,
           "aoe_range": 0.0,
@@ -13,8 +15,8 @@
           "damage": 0.0,
           "damage_multiplier": 0.0,
           "dot_damage": 0.0,
-          "piercing": 0.0,
-          "piercing_reduction": 0.0,
+          "pierce_count": 0.0,
+          "pierce_reduction": 0.0,
           "speed": 0.0
         }
       },
@@ -26,6 +28,8 @@
         "cost": 50,
         "fire_rate": 1.5,
         "shoot_range": 150.0,
+        "projectile_count": 1,
+        "spread_angle": 15.0,
         "bullet_stats": {
           "aoe_duration": 0.0,
           "aoe_range": 0.0,
@@ -33,8 +37,8 @@
           "damage": 0.0,
           "damage_multiplier": 0.0,
           "dot_damage": 0.0,
-          "piercing": 0.0,
-          "piercing_reduction": 0.0,
+          "pierce_count": 0.0,
+          "pierce_reduction": 0.0,
           "speed": 0.0
         }
       },

--- a/project.godot
+++ b/project.godot
@@ -22,6 +22,7 @@ SoundManager="*res://scripts/autoloads/sound_manager.gd"
 ScenesLoader="*res://scripts/autoloads/scenes_loader.gd"
 Dialogic="*res://addons/dialogic/Core/DialogicGameHandler.gd"
 ProgressionManager="*res://scripts/autoloads/progression_manager.gd"
+StatsDB="*res://scripts/autoloads/stats_db.gd"
 
 [dialogic]
 

--- a/scenes/gameplay/entities/enemy/enemies/big_daddy.gd
+++ b/scenes/gameplay/entities/enemy/enemies/big_daddy.gd
@@ -7,22 +7,17 @@ extends IEnemy
 @export_subgroup("Shooting Configuration")
 ## The projectile scene to be instantiated by the enemy
 @export var projectile_scene: PackedScene = null
-## The shooting range of the enemy
-@export var shoot_range: float = 150.0
-## The fire rate of the enemy (shots per second)
-@export var fire_rate: float = 0.5
-## The duration in seconds that a tower is disabled when hit by a projectile
-@export var tower_disable_duration: float = 3.0
+## Runtime stats loaded from StatsDB (JSON); defaults kept neutral here
+var shoot_range: float = 0.0
+var fire_rate: float = 0.0
+var tower_disable_duration: float = 0.0
 
 @export_subgroup("Attack Cycle Configuration")
-## Time to wait before starting an attack after detecting a target.
-@export var pre_attack_delay: float = 1.0
-## Duration of the attack phase (shooting).
-@export var attack_duration: float = 1.0
-## Time to wait after an attack before resuming movement.
-@export var post_attack_delay: float = 1.0
-## Cooldown time between full attack cycles.
-@export var attack_cooldown: float = 5.0
+## Runtime stats loaded from StatsDB (JSON); defaults kept neutral here
+var pre_attack_delay: float = 0.0
+var attack_duration: float = 0.0
+var post_attack_delay: float = 0.0
+var attack_cooldown: float = 0.0
 
 
 # Onready variables
@@ -112,6 +107,7 @@ func _apply_extra_stats_override() -> void:
 		return
 	var data: Dictionary = stats_db.get_enemy(enemy_id)
 	var extra: Dictionary = data.get("extra", {})
+	Log.trace(Log.Level.INFO, "Applying big_daddy extra stats from StatsDB: %s" % extra)
 	if extra.has("shoot_range"):
 		shoot_range = float(extra["shoot_range"])
 	if extra.has("fire_rate"):

--- a/scenes/gameplay/entities/enemy/enemies/big_daddy.gd
+++ b/scenes/gameplay/entities/enemy/enemies/big_daddy.gd
@@ -24,6 +24,8 @@ extends IEnemy
 ## Cooldown time between full attack cycles.
 @export var attack_cooldown: float = 5.0
 
+@onready var stats_db: StatsDB = StatsDB
+
 # Onready variables
 ## The area 2D node for the enemy to detect towers in range
 @onready var range_area: Area2D = $RangeArea
@@ -56,6 +58,7 @@ var current_target: Node2D = null
 
 
 func _ready() -> void:
+	_apply_extra_stats_override()
 	super._ready() # Call the parent class's _ready function
 
 	# Ensure nodes are ready before connecting signals or configuring them
@@ -101,6 +104,29 @@ func _ready() -> void:
 
 	# Initial check for targets already in range
 	_find_new_target()
+
+
+func _apply_extra_stats_override() -> void:
+	if enemy_id.is_empty():
+		return
+	if not stats_db.has_enemy(enemy_id):
+		return
+	var data := stats_db.get_enemy(enemy_id)
+	var extra := data.get("extra", {})
+	if extra.has("shoot_range"):
+		shoot_range = float(extra["shoot_range"])
+	if extra.has("fire_rate"):
+		fire_rate = float(extra["fire_rate"])
+	if extra.has("tower_disable_duration"):
+		tower_disable_duration = float(extra["tower_disable_duration"])
+	if extra.has("pre_attack_delay"):
+		pre_attack_delay = float(extra["pre_attack_delay"])
+	if extra.has("attack_duration"):
+		attack_duration = float(extra["attack_duration"])
+	if extra.has("post_attack_delay"):
+		post_attack_delay = float(extra["post_attack_delay"])
+	if extra.has("attack_cooldown"):
+		attack_cooldown = float(extra["attack_cooldown"])
 
 
 func _physics_process(delta: float) -> void:

--- a/scenes/gameplay/entities/enemy/enemies/big_daddy.gd
+++ b/scenes/gameplay/entities/enemy/enemies/big_daddy.gd
@@ -24,7 +24,6 @@ extends IEnemy
 ## Cooldown time between full attack cycles.
 @export var attack_cooldown: float = 5.0
 
-@onready var stats_db: StatsDB = StatsDB
 
 # Onready variables
 ## The area 2D node for the enemy to detect towers in range
@@ -107,12 +106,12 @@ func _ready() -> void:
 
 
 func _apply_extra_stats_override() -> void:
-	if enemy_id.is_empty():
+	if enemy_id.is_empty() or stats_db == null:
 		return
 	if not stats_db.has_enemy(enemy_id):
 		return
-	var data := stats_db.get_enemy(enemy_id)
-	var extra := data.get("extra", {})
+	var data: Dictionary = stats_db.get_enemy(enemy_id)
+	var extra: Dictionary = data.get("extra", {})
 	if extra.has("shoot_range"):
 		shoot_range = float(extra["shoot_range"])
 	if extra.has("fire_rate"):

--- a/scenes/gameplay/entities/enemy/enemies/big_daddy.tscn
+++ b/scenes/gameplay/entities/enemy/enemies/big_daddy.tscn
@@ -137,10 +137,19 @@ size = Vector2(41, 81.5001)
 radius = 214.189
 
 [node name="BigDaddy" instance=ExtResource("1_o4ric")]
-enemy_id = "big_daddy"
 position = Vector2(0, -22)
 script = ExtResource("2_3ulna")
 projectile_scene = ExtResource("3_nitix")
+shoot_range = 150.0
+fire_rate = 0.5
+tower_disable_duration = 3.0
+pre_attack_delay = 1.0
+attack_duration = 1.0
+post_attack_delay = 1.0
+attack_cooldown = 5.0
+max_health = 20.0
+speed = 30.0
+enemy_id = "big_daddy"
 type = 0
 
 [node name="AnimatedSprite2D" parent="." index="0"]

--- a/scenes/gameplay/entities/enemy/enemies/big_daddy.tscn
+++ b/scenes/gameplay/entities/enemy/enemies/big_daddy.tscn
@@ -137,18 +137,10 @@ size = Vector2(41, 81.5001)
 radius = 214.189
 
 [node name="BigDaddy" instance=ExtResource("1_o4ric")]
+enemy_id = "big_daddy"
 position = Vector2(0, -22)
 script = ExtResource("2_3ulna")
 projectile_scene = ExtResource("3_nitix")
-shoot_range = 100.0
-fire_rate = 100.0
-tower_disable_duration = 3.0
-pre_attack_delay = 1.0
-attack_duration = 1.0
-post_attack_delay = 1.0
-attack_cooldown = 5.0
-max_health = 1000.0
-speed = 20.0
 type = 0
 
 [node name="AnimatedSprite2D" parent="." index="0"]

--- a/scenes/gameplay/entities/enemy/enemies/big_daddy.tscn
+++ b/scenes/gameplay/entities/enemy/enemies/big_daddy.tscn
@@ -140,15 +140,6 @@ radius = 214.189
 position = Vector2(0, -22)
 script = ExtResource("2_3ulna")
 projectile_scene = ExtResource("3_nitix")
-shoot_range = 150.0
-fire_rate = 0.5
-tower_disable_duration = 3.0
-pre_attack_delay = 1.0
-attack_duration = 1.0
-post_attack_delay = 1.0
-attack_cooldown = 5.0
-max_health = 20.0
-speed = 30.0
 enemy_id = "big_daddy"
 type = 0
 

--- a/scenes/gameplay/entities/enemy/enemies/ene.01.tscn
+++ b/scenes/gameplay/entities/enemy/enemies/ene.01.tscn
@@ -134,8 +134,6 @@ size = Vector2(23, 61.4118)
 [node name="DefaultZombie" instance=ExtResource("1_rsmel")]
 enemy_id = "default_zombie"
 position = Vector2(0, -16)
-max_health = 20.0
-speed = 45.0
 type = 1
 
 [node name="AnimatedSprite2D" parent="." index="0"]

--- a/scenes/gameplay/entities/enemy/enemies/ene.01.tscn
+++ b/scenes/gameplay/entities/enemy/enemies/ene.01.tscn
@@ -132,6 +132,7 @@ animations = [{
 size = Vector2(23, 61.4118)
 
 [node name="DefaultZombie" instance=ExtResource("1_rsmel")]
+enemy_id = "default_zombie"
 position = Vector2(0, -16)
 max_health = 20.0
 speed = 45.0

--- a/scenes/gameplay/entities/enemy/enemies/ene.01.tscn
+++ b/scenes/gameplay/entities/enemy/enemies/ene.01.tscn
@@ -132,8 +132,10 @@ animations = [{
 size = Vector2(23, 61.4118)
 
 [node name="DefaultZombie" instance=ExtResource("1_rsmel")]
-enemy_id = "default_zombie"
 position = Vector2(0, -16)
+max_health = 20.0
+speed = 30.0
+enemy_id = "default_zombie"
 type = 1
 
 [node name="AnimatedSprite2D" parent="." index="0"]

--- a/scenes/gameplay/entities/enemy/enemies/ene.01.tscn
+++ b/scenes/gameplay/entities/enemy/enemies/ene.01.tscn
@@ -133,8 +133,6 @@ size = Vector2(23, 61.4118)
 
 [node name="DefaultZombie" instance=ExtResource("1_rsmel")]
 position = Vector2(0, -16)
-max_health = 20.0
-speed = 30.0
 enemy_id = "default_zombie"
 type = 1
 

--- a/scenes/gameplay/entities/enemy/enemies/ene.02.tscn
+++ b/scenes/gameplay/entities/enemy/enemies/ene.02.tscn
@@ -132,6 +132,7 @@ animations = [{
 size = Vector2(22, 63)
 
 [node name="DamageZombie" instance=ExtResource("1_pdmcd")]
+enemy_id = "damage_zombie"
 position = Vector2(0, -27)
 max_health = 100.0
 speed = 30.0

--- a/scenes/gameplay/entities/enemy/enemies/ene.02.tscn
+++ b/scenes/gameplay/entities/enemy/enemies/ene.02.tscn
@@ -132,8 +132,10 @@ animations = [{
 size = Vector2(22, 63)
 
 [node name="DamageZombie" instance=ExtResource("1_pdmcd")]
-enemy_id = "damage_zombie"
 position = Vector2(0, -27)
+max_health = 20.0
+speed = 30.0
+enemy_id = "damage_zombie"
 type = 1
 
 [node name="AnimatedSprite2D" parent="." index="0"]

--- a/scenes/gameplay/entities/enemy/enemies/ene.02.tscn
+++ b/scenes/gameplay/entities/enemy/enemies/ene.02.tscn
@@ -133,8 +133,6 @@ size = Vector2(22, 63)
 
 [node name="DamageZombie" instance=ExtResource("1_pdmcd")]
 position = Vector2(0, -27)
-max_health = 20.0
-speed = 30.0
 enemy_id = "damage_zombie"
 type = 1
 

--- a/scenes/gameplay/entities/enemy/enemies/ene.02.tscn
+++ b/scenes/gameplay/entities/enemy/enemies/ene.02.tscn
@@ -134,8 +134,6 @@ size = Vector2(22, 63)
 [node name="DamageZombie" instance=ExtResource("1_pdmcd")]
 enemy_id = "damage_zombie"
 position = Vector2(0, -27)
-max_health = 100.0
-speed = 30.0
 type = 1
 
 [node name="AnimatedSprite2D" parent="." index="0"]

--- a/scenes/gameplay/entities/enemy/enemies/ene.03.tscn
+++ b/scenes/gameplay/entities/enemy/enemies/ene.03.tscn
@@ -48,8 +48,10 @@ animations = [{
 size = Vector2(44, 66)
 
 [node name="Rat" instance=ExtResource("1_dhx8w")]
-enemy_id = "rat"
 position = Vector2(0, -10)
+max_health = 20.0
+speed = 30.0
+enemy_id = "rat"
 type = 3
 
 [node name="AnimatedSprite2D" parent="." index="0"]

--- a/scenes/gameplay/entities/enemy/enemies/ene.03.tscn
+++ b/scenes/gameplay/entities/enemy/enemies/ene.03.tscn
@@ -50,8 +50,6 @@ size = Vector2(44, 66)
 [node name="Rat" instance=ExtResource("1_dhx8w")]
 enemy_id = "rat"
 position = Vector2(0, -10)
-max_health = 10.0
-speed = 100.0
 type = 3
 
 [node name="AnimatedSprite2D" parent="." index="0"]

--- a/scenes/gameplay/entities/enemy/enemies/ene.03.tscn
+++ b/scenes/gameplay/entities/enemy/enemies/ene.03.tscn
@@ -48,6 +48,7 @@ animations = [{
 size = Vector2(44, 66)
 
 [node name="Rat" instance=ExtResource("1_dhx8w")]
+enemy_id = "rat"
 position = Vector2(0, -10)
 max_health = 10.0
 speed = 100.0

--- a/scenes/gameplay/entities/enemy/enemies/ene.03.tscn
+++ b/scenes/gameplay/entities/enemy/enemies/ene.03.tscn
@@ -49,8 +49,6 @@ size = Vector2(44, 66)
 
 [node name="Rat" instance=ExtResource("1_dhx8w")]
 position = Vector2(0, -10)
-max_health = 20.0
-speed = 30.0
 enemy_id = "rat"
 type = 3
 

--- a/scenes/gameplay/entities/enemy/i_enemy.gd
+++ b/scenes/gameplay/entities/enemy/i_enemy.gd
@@ -52,8 +52,8 @@ const DAMAGES: Dictionary = {
 	DamageType.FIRE: {"color": Color(1.0, 0.3, 0.1, 1)},
 }
 
-@export var max_health: float = 20.0
-@export var speed: float = 30.0
+var max_health: float = 0.0
+var speed: float = 0.0
 @export var enemy_id: String = ""
 @onready var stats_db = get_node("/root/StatsDB")
 @export var type: EnemyType = EnemyType.DEFAULT
@@ -302,8 +302,10 @@ func _apply_stats_override() -> void:
 	if enemy_id.is_empty() or stats_db == null:
 		return
 	if not stats_db.has_enemy(enemy_id):
+		Log.trace(Log.Level.ERROR, "StatsDB missing enemy id: %s" % enemy_id)
 		return
 	var data: Dictionary = stats_db.get_enemy(enemy_id)
+	Log.trace(Log.Level.INFO, "Applying enemy stats from StatsDB for %s: %s" % [enemy_id, data])
 	var hp = data.get("max_health", null)
 	var spd = data.get("speed", null)
 	if hp != null:

--- a/scenes/gameplay/entities/enemy/i_enemy.gd
+++ b/scenes/gameplay/entities/enemy/i_enemy.gd
@@ -55,7 +55,7 @@ const DAMAGES: Dictionary = {
 @export var max_health: float = 20.0
 @export var speed: float = 30.0
 @export var enemy_id: String = ""
-@onready var stats_db: StatsDB = StatsDB
+@onready var stats_db = get_node("/root/StatsDB")
 @export var type: EnemyType = EnemyType.DEFAULT
 
 var active_poison_timers: Array[Dictionary] = []
@@ -299,11 +299,11 @@ func _path_finished_state() -> void:
 
 
 func _apply_stats_override() -> void:
-	if enemy_id.is_empty():
+	if enemy_id.is_empty() or stats_db == null:
 		return
 	if not stats_db.has_enemy(enemy_id):
 		return
-	var data := stats_db.get_enemy(enemy_id)
+	var data: Dictionary = stats_db.get_enemy(enemy_id)
 	var hp = data.get("max_health", null)
 	var spd = data.get("speed", null)
 	if hp != null:

--- a/scenes/gameplay/entities/enemy/i_enemy.gd
+++ b/scenes/gameplay/entities/enemy/i_enemy.gd
@@ -54,6 +54,8 @@ const DAMAGES: Dictionary = {
 
 @export var max_health: float = 20.0
 @export var speed: float = 30.0
+@export var enemy_id: String = ""
+@onready var stats_db: StatsDB = StatsDB
 @export var type: EnemyType = EnemyType.DEFAULT
 
 var active_poison_timers: Array[Dictionary] = []
@@ -79,6 +81,7 @@ var state: EnemyState = EnemyState.FOLLOW_PATH
 
 # core
 func _ready() -> void:
+	_apply_stats_override()
 	if type == EnemyType.FAT or type == EnemyType.BIG_DADDY:
 		camera_effect.connect(Global.camera.handle_effect)
 		camera_effect.emit('shake')
@@ -293,6 +296,20 @@ func _path_finished_state() -> void:
 		ILevel.current_level.health = 0
 	else:
 		ILevel.current_level.health -= ceil(health / 2)
+
+
+func _apply_stats_override() -> void:
+	if enemy_id.is_empty():
+		return
+	if not stats_db.has_enemy(enemy_id):
+		return
+	var data := stats_db.get_enemy(enemy_id)
+	var hp = data.get("max_health", null)
+	var spd = data.get("speed", null)
+	if hp != null:
+		max_health = float(hp)
+	if spd != null:
+		speed = float(spd)
 
 ## Update the z-index of the enemy based on its position
 func _update_z_index() -> void:

--- a/scenes/gameplay/entities/enemy/i_enemy.gd
+++ b/scenes/gameplay/entities/enemy/i_enemy.gd
@@ -11,6 +11,8 @@ signal die
 ## [param effect] The name of the effect to trigger
 signal camera_effect(effect: String)
 
+
+# Enums
 ## Possible states for the enemy
 enum EnemyState {
 	DEAD,  ## Enemy is dead
@@ -41,6 +43,8 @@ enum DamageType {
 	FIRE,
 }
 
+
+# Constants
 const ANIM_FADE_OUT := "fade_out"
 const ANIM_WALK_UP := "walk_up"
 const ANIM_WALK_DOWN := "walk_down"
@@ -52,21 +56,23 @@ const DAMAGES: Dictionary = {
 	DamageType.FIRE: {"color": Color(1.0, 0.3, 0.1, 1)},
 }
 
-var max_health: float = 0.0
-var speed: float = 0.0
+
+# Exported variables
 @export var enemy_id: String = ""
-@onready var stats_db = get_node("/root/StatsDB")
 @export var type: EnemyType = EnemyType.DEFAULT
 
+# Public variables
 var active_poison_timers: Array[Dictionary] = []
 var current_animation: String = ""
 var direction: EnemyDirection = EnemyDirection.UP_RIGHT
 var health: float
 var is_already_dead: bool = false
+var max_health: float = 0.0
 var path: Path2D = null
 var path_follow: PathFollow2D = null
 var poison_timer_execution_count: int = 0
 var previous_position: Vector2 = Vector2.ZERO
+var speed: float = 0.0
 var state: EnemyState = EnemyState.FOLLOW_PATH
 
 ## Must be placed first as it is used in other onready variables
@@ -78,8 +84,10 @@ var state: EnemyState = EnemyState.FOLLOW_PATH
 @onready var path_points_size: int = path.curve.point_count
 @onready var poison_particle: GPUParticles2D = $GPUParticles2D
 @onready var popup_score_spawner: PopupSpawner = $PopupScoreSpawner
+@onready var stats_db = get_node("/root/StatsDB")
 
-# core
+
+# Built-in functions
 func _ready() -> void:
 	_apply_stats_override()
 	if type == EnemyType.FAT or type == EnemyType.BIG_DADDY:
@@ -96,6 +104,7 @@ func _ready() -> void:
 
 	# Force initial animation to match direction
 	_walk()
+
 
 func _physics_process(delta: float) -> void:
 	if is_already_dead or Global.paused:
@@ -115,7 +124,8 @@ func _physics_process(delta: float) -> void:
 
 	poison_particle.emitting = not active_poison_timers.is_empty()
 
-# public
+
+# Public functions
 ## Apply damage to the enemy
 ## [br]
 ## [param damage] Amount of damage to apply
@@ -131,6 +141,7 @@ func take_damage(damage: float, damage_type: DamageType) -> void:
 	else:
 		health -= damage
 
+
 ## Update enemy position along its path
 ## [br]
 ## [param delta] Time since last frame
@@ -144,6 +155,7 @@ func follow_path(delta: float) -> void:
 	# Always update direction, regardless of path position
 	_update_direction()
 	_walk()
+
 
 ## Add a poison effect to the enemy
 ## [br]
@@ -167,7 +179,8 @@ func add_poison_effect(damage: float, total_execution: int, interval: float) -> 
 
 	poison_timer.timeout.connect(func(): _on_poison_timer_timeout(poison_timer))
 
-# private
+
+# Private functions
 ## Apply a damage effect to the enemy sprite
 func _damage_effect(color: Color) -> void:
 	sprite.modulate = color

--- a/scenes/gameplay/entities/tower/i_tower.gd
+++ b/scenes/gameplay/entities/tower/i_tower.gd
@@ -38,34 +38,26 @@ enum TowerType {
 ## The bullet scene to be instantiated by the tower
 @export var bullet_scene: PackedScene = null
 
-## The bullet stats to be applied to the bullet
-@export var bullet_stats: Dictionary = {
-	"damage": 0.0, ## Base damage increase
-	"speed": 0.0, ## Projectile speed modifier
-	"pierce_count": 0.0, ## Armor penetration value
-	"pierce_reduction": 0.0, ## Reduction in piercing effectiveness
-	"aoe_range": 0.0, ## Area of effect range
-	"burn_duration": 0.0, ## Duration of the burn effect
-	"burn_damage_base": 0.0, ## Base damage of the burn effect
-}
+## The bullet stats to be applied to the bullet (overridden at runtime from StatsDB)
+var bullet_stats: Dictionary = {}
 
 @export_subgroup("Multi-Shot Properties")
-## The number of projectiles to fire simultaneously
-@export var projectile_count: int = 1
-## The angle spread between multiple projectiles (in degrees)
-@export var spread_angle: float = 15.0
+## The number of projectiles to fire simultaneously (overridden at runtime)
+var projectile_count: int = 0
+## The angle spread between multiple projectiles (in degrees) (overridden at runtime)
+var spread_angle: float = 0.0
 
 @export_subgroup("Tower Properties")
-## The cost of the tower
-@export var cost: int
-## The fire rate of the tower
-@export var fire_rate: float
-## The level of the tower
-@export var level: int
-## The sell price of the tower
-@export var sell_price: int
-## The shooting range of the tower
-@export var shoot_range: float
+## The cost of the tower (overridden at runtime)
+var cost: int = 0
+## The fire rate of the tower (overridden at runtime)
+var fire_rate: float = 0.0
+## The level of the tower (overridden at runtime)
+var level: int = 0
+## The sell price of the tower (computed)
+var sell_price: int = 0
+## The shooting range of the tower (overridden at runtime)
+var shoot_range: float = 0.0
 
 @export_subgroup("Upgrades")
 ## The upgrade array to store upgrades that are applied in the tower
@@ -292,15 +284,21 @@ func _apply_base_stats_override() -> void:
 	if tower_id.is_empty() or stats_db == null:
 		return
 	if not stats_db.has_tower(tower_id):
+		Log.trace(Log.Level.ERROR, "StatsDB missing tower id: %s" % tower_id)
 		return
 	var data: Dictionary = stats_db.get_tower(tower_id)
 	var base: Dictionary = data.get("base", {})
+	Log.trace(Log.Level.INFO, "Applying tower stats from StatsDB for %s: %s" % [tower_id, base])
 	if base.has("cost"):
 		cost = int(base["cost"])
 	if base.has("fire_rate"):
 		fire_rate = float(base["fire_rate"])
 	if base.has("shoot_range"):
 		shoot_range = float(base["shoot_range"])
+	if base.has("projectile_count"):
+		projectile_count = int(base["projectile_count"])
+	if base.has("spread_angle"):
+		spread_angle = float(base["spread_angle"])
 	if base.has("bullet_stats"):
 		var bs: Dictionary = base["bullet_stats"]
 		for k in bs.keys():

--- a/scenes/gameplay/entities/tower/i_tower.gd
+++ b/scenes/gameplay/entities/tower/i_tower.gd
@@ -109,10 +109,13 @@ var target: IEnemy
 var target_type: TargetType
 ## The pending upgrade to be applied
 var pending_upgrade: PackedScene
+@onready var stats_db: StatsDB = StatsDB
+@export var tower_id: String = ""
 
 # Core methods
 func _ready() -> void:
 	target_type = TargetType.FIRST
+	_apply_base_stats_override()
 	sell_price = ceil(cost / 2.0)
 	hover_box.z_index = 3
 	update_dependent_properties()
@@ -283,6 +286,25 @@ func _apply_bullet_modifications(bullet_instance: IBullet) -> void:
 
 	bullet_instance.damage += bullet_stats["damage"]
 	bullet_instance.speed += bullet_stats["speed"]
+
+
+func _apply_base_stats_override() -> void:
+	if tower_id.is_empty():
+		return
+	if not stats_db.has_tower(tower_id):
+		return
+	var data := stats_db.get_tower(tower_id)
+	var base := data.get("base", {})
+	if base.has("cost"):
+		cost = int(base["cost"])
+	if base.has("fire_rate"):
+		fire_rate = float(base["fire_rate"])
+	if base.has("shoot_range"):
+		shoot_range = float(base["shoot_range"])
+	if base.has("bullet_stats"):
+		var bs: Dictionary = base["bullet_stats"]
+		for k in bs.keys():
+			bullet_stats[k] = bs[k]
 
 func _choose_target() -> void:
 	match target_type:

--- a/scenes/gameplay/entities/tower/i_tower.gd
+++ b/scenes/gameplay/entities/tower/i_tower.gd
@@ -109,7 +109,7 @@ var target: IEnemy
 var target_type: TargetType
 ## The pending upgrade to be applied
 var pending_upgrade: PackedScene
-@onready var stats_db: StatsDB = StatsDB
+@onready var stats_db = get_node("/root/StatsDB")
 @export var tower_id: String = ""
 
 # Core methods
@@ -289,12 +289,12 @@ func _apply_bullet_modifications(bullet_instance: IBullet) -> void:
 
 
 func _apply_base_stats_override() -> void:
-	if tower_id.is_empty():
+	if tower_id.is_empty() or stats_db == null:
 		return
 	if not stats_db.has_tower(tower_id):
 		return
-	var data := stats_db.get_tower(tower_id)
-	var base := data.get("base", {})
+	var data: Dictionary = stats_db.get_tower(tower_id)
+	var base: Dictionary = data.get("base", {})
 	if base.has("cost"):
 		cost = int(base["cost"])
 	if base.has("fire_rate"):

--- a/scenes/gameplay/entities/tower/towers/bat_01.tscn
+++ b/scenes/gameplay/entities/tower/towers/bat_01.tscn
@@ -102,21 +102,6 @@ height = 36.0
 tower_id = "bat_01"
 position = Vector2(0, -16)
 bullet_scene = ExtResource("2_g3vd4")
-bullet_stats = {
-"aoe_duration": 0.0,
-"aoe_range": 0.0,
-"aoe_tick": 0.0,
-"damage": 0.0,
-"damage_multiplier": 0.0,
-"dot_damage": 0.0,
-"piercing": 0.0,
-"piercing_reduction": 0.0,
-"speed": 0.0
-}
-cost = 50
-fire_rate = 1.5
-level = 1
-shoot_range = 100.0
 
 [node name="AnimatedSprite2D" parent="." index="0"]
 sprite_frames = SubResource("SpriteFrames_1t44q")

--- a/scenes/gameplay/entities/tower/towers/bat_01.tscn
+++ b/scenes/gameplay/entities/tower/towers/bat_01.tscn
@@ -99,6 +99,7 @@ height = 36.0
 [sub_resource type="CircleShape2D" id="CircleShape2D_hnqt7"]
 
 [node name="Bat01" instance=ExtResource("1_tpm17")]
+tower_id = "bat_01"
 position = Vector2(0, -16)
 bullet_scene = ExtResource("2_g3vd4")
 bullet_stats = {

--- a/scenes/gameplay/entities/tower/towers/bat_01.tscn
+++ b/scenes/gameplay/entities/tower/towers/bat_01.tscn
@@ -99,9 +99,9 @@ height = 36.0
 [sub_resource type="CircleShape2D" id="CircleShape2D_hnqt7"]
 
 [node name="Bat01" instance=ExtResource("1_tpm17")]
-tower_id = "bat_01"
 position = Vector2(0, -16)
 bullet_scene = ExtResource("2_g3vd4")
+tower_id = "bat_01"
 
 [node name="AnimatedSprite2D" parent="." index="0"]
 sprite_frames = SubResource("SpriteFrames_1t44q")

--- a/scenes/gameplay/entities/tower/towers/bat_02.tscn
+++ b/scenes/gameplay/entities/tower/towers/bat_02.tscn
@@ -100,10 +100,10 @@ height = 36.0
 [sub_resource type="CircleShape2D" id="CircleShape2D_hnqt7"]
 
 [node name="Bat02" instance=ExtResource("1_yt4jj")]
-tower_id = "bat_02"
 position = Vector2(0, -16)
 bullet_scene = ExtResource("2_pv1tv")
 available_upgrade = Array[PackedScene]([ExtResource("3_sq6hj")])
+tower_id = "bat_02"
 
 [node name="AnimatedSprite2D" parent="." index="0"]
 sprite_frames = SubResource("SpriteFrames_ynjgg")

--- a/scenes/gameplay/entities/tower/towers/bat_02.tscn
+++ b/scenes/gameplay/entities/tower/towers/bat_02.tscn
@@ -103,21 +103,6 @@ height = 36.0
 tower_id = "bat_02"
 position = Vector2(0, -16)
 bullet_scene = ExtResource("2_pv1tv")
-bullet_stats = {
-"aoe_duration": 0.0,
-"aoe_range": 0.0,
-"aoe_tick": 0.0,
-"damage": 0.0,
-"damage_multiplier": 0.0,
-"dot_damage": 0.0,
-"piercing": 0.0,
-"piercing_reduction": 0.0,
-"speed": 0.0
-}
-cost = 50
-fire_rate = 1.5
-level = 1
-shoot_range = 150.0
 available_upgrade = Array[PackedScene]([ExtResource("3_sq6hj")])
 
 [node name="AnimatedSprite2D" parent="." index="0"]

--- a/scenes/gameplay/entities/tower/towers/bat_02.tscn
+++ b/scenes/gameplay/entities/tower/towers/bat_02.tscn
@@ -100,6 +100,7 @@ height = 36.0
 [sub_resource type="CircleShape2D" id="CircleShape2D_hnqt7"]
 
 [node name="Bat02" instance=ExtResource("1_yt4jj")]
+tower_id = "bat_02"
 position = Vector2(0, -16)
 bullet_scene = ExtResource("2_pv1tv")
 bullet_stats = {

--- a/scenes/ui/menus/tower_upgrade/tower_upgrade_menu.gd
+++ b/scenes/ui/menus/tower_upgrade/tower_upgrade_menu.gd
@@ -4,6 +4,7 @@ extends Control
 var sell_price: int
 var tower: ITower
 var upgrade_price: int
+@onready var stats_db: StatsDB = StatsDB
 
 @onready var close_button: TextureButton = $VBoxContainer/CloseAspectRatioContainer/CloseTextureButton
 @onready var sell_button: TextureButton = $VBoxContainer/HBoxContainer/SellAspectRatioContainer/SellTextureButton
@@ -24,8 +25,7 @@ func _ready() -> void:
 	sell_price = tower.sell_price
 	sell_label.text = str(sell_price)+"$"
 	if !tower.available_upgrade.is_empty():
-		var upg: IUpgrade = tower.available_upgrade[0].instantiate()
-		upgrade_price = upg.price
+		upgrade_price = _resolve_upgrade_price(tower.available_upgrade[0])
 		upgrade_label.text = str(upgrade_price)+"$"
 	else:
 		upgrade_button.disabled = true
@@ -78,3 +78,18 @@ func _on_sell_button_pressed():
 func _on_upgrade_button_pressed():
 	tower.start_upgrade(tower.available_upgrade[0])
 	_on_close_button_pressed()
+
+
+func _resolve_upgrade_price(upgrade_scene: PackedScene) -> int:
+	if upgrade_scene == null:
+		return 0
+	var upgrade_path: String = upgrade_scene.resource_path
+	if not upgrade_path.is_empty():
+		var upgrade_id := stats_db.upgrade_id_from_scene(upgrade_path)
+		if not upgrade_id.is_empty():
+			var upgrade_data := stats_db.get_upgrade(upgrade_id)
+			var price = upgrade_data.get("price", null)
+			if price != null:
+				return int(price)
+	var upg: IUpgrade = upgrade_scene.instantiate()
+	return upg.price

--- a/scenes/ui/menus/tower_upgrade/tower_upgrade_menu.gd
+++ b/scenes/ui/menus/tower_upgrade/tower_upgrade_menu.gd
@@ -1,17 +1,17 @@
 class_name TowerUpgradeMenu
 extends Control
 
+# Public variables
 var sell_price: int
 var tower: ITower
 var upgrade_price: int
-@onready var stats_db = get_node("/root/StatsDB")
 
+@onready var stats_db = get_node("/root/StatsDB")
 @onready var close_button: TextureButton = $VBoxContainer/CloseAspectRatioContainer/CloseTextureButton
 @onready var sell_button: TextureButton = $VBoxContainer/HBoxContainer/SellAspectRatioContainer/SellTextureButton
 @onready var sell_label: Label = $VBoxContainer/HBoxContainer/SellAspectRatioContainer/SellLabel
 @onready var upgrade_button: TextureButton = $VBoxContainer/HBoxContainer/UpgradeAspectRatioContainer/UpgradeTextureButton
 @onready var upgrade_label: Label = $VBoxContainer/HBoxContainer/UpgradeAspectRatioContainer/UpgradeLabel
-
 @onready var signals: Array[Dictionary] = [
 	{SignalUtil.WHO: close_button, SignalUtil.WHAT: "pressed", SignalUtil.TO: _on_close_button_pressed},
 	{SignalUtil.WHO: upgrade_button, SignalUtil.WHAT: "pressed", SignalUtil.TO: _on_upgrade_button_pressed},
@@ -19,6 +19,7 @@ var upgrade_price: int
 ]
 
 
+# Built-in functions
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	tower = get_parent() as ITower
@@ -32,25 +33,26 @@ func _ready() -> void:
 		# Change upgrade button to gray rbg #525252
 		upgrade_button.modulate = Color(0.325, 0.325, 0.325)  # Gray color
 		upgrade_label.text = "MAX"
-	
+
 	# Connect to level stats updates to refresh button state when coins change
 	if ILevel.current_level:
 		ILevel.current_level.stats_updated.connect(_on_level_stats_updated)
-	
+
 	# Update button state initially
 	_update_upgrade_button_state()
-	
+
 	SignalUtil.connects(signals)
 
 
+# Private functions
 ## Updates the visual state of the upgrade button based on available coins
 func _update_upgrade_button_state() -> void:
 	# Only check money if there's an upgrade available
 	if tower.available_upgrade.is_empty():
 		return
-	
+
 	var can_afford: bool = ILevel.current_level.coins >= upgrade_price
-	
+
 	if can_afford:
 		upgrade_button.modulate = Color(1.0, 1.0, 1.0)  # White (enabled)
 		upgrade_button.disabled = false

--- a/scenes/ui/menus/tower_upgrade/tower_upgrade_menu.gd
+++ b/scenes/ui/menus/tower_upgrade/tower_upgrade_menu.gd
@@ -4,7 +4,7 @@ extends Control
 var sell_price: int
 var tower: ITower
 var upgrade_price: int
-@onready var stats_db: StatsDB = StatsDB
+@onready var stats_db = get_node("/root/StatsDB")
 
 @onready var close_button: TextureButton = $VBoxContainer/CloseAspectRatioContainer/CloseTextureButton
 @onready var sell_button: TextureButton = $VBoxContainer/HBoxContainer/SellAspectRatioContainer/SellTextureButton
@@ -84,10 +84,10 @@ func _resolve_upgrade_price(upgrade_scene: PackedScene) -> int:
 	if upgrade_scene == null:
 		return 0
 	var upgrade_path: String = upgrade_scene.resource_path
-	if not upgrade_path.is_empty():
-		var upgrade_id := stats_db.upgrade_id_from_scene(upgrade_path)
+	if not upgrade_path.is_empty() and stats_db != null:
+		var upgrade_id: String = stats_db.upgrade_id_from_scene(upgrade_path)
 		if not upgrade_id.is_empty():
-			var upgrade_data := stats_db.get_upgrade(upgrade_id)
+			var upgrade_data: Dictionary = stats_db.get_upgrade(upgrade_id)
 			var price = upgrade_data.get("price", null)
 			if price != null:
 				return int(price)

--- a/scripts/autoloads/stats_db.gd
+++ b/scripts/autoloads/stats_db.gd
@@ -12,6 +12,10 @@ var _upgrade_by_scene: Dictionary = {}
 func _ready() -> void:
 	_data = _load_json(STATS_PATH)
 	_index_upgrades_by_scene()
+	var towers_count: int = _data.get("towers", {}).size()
+	var enemies_count: int = _data.get("enemies", {}).size()
+	var upgrades_count: int = _data.get("upgrades", {}).size()
+	Log.trace(Log.Level.INFO, "StatsDB loaded: towers=%s, enemies=%s, upgrades=%s" % [towers_count, enemies_count, upgrades_count])
 
 
 func get_tower(id: String) -> Dictionary:

--- a/scripts/autoloads/stats_db.gd
+++ b/scripts/autoloads/stats_db.gd
@@ -1,7 +1,6 @@
 ## © [2024] A7 Studio. All rights reserved. Trademark.
 ##
 ## Charge et expose les stats centralisées (tours, upgrades, ennemis) depuis un JSON.
-class_name StatsDB
 extends Node
 
 const STATS_PATH: String = "res://assets/resources/configs/stats.json"
@@ -52,7 +51,7 @@ func has_enemy(id: String) -> bool:
 func load_packed_scene(path: String) -> PackedScene:
 	if path.is_empty():
 		return null
-	var res := load(path)
+	var res: Resource = load(path)
 	return res if res is PackedScene else null
 
 
@@ -60,8 +59,8 @@ func _load_json(path: String) -> Dictionary:
 	if not FileAccess.file_exists(path):
 		push_warning("StatsDB: fichier introuvable %s" % path)
 		return {}
-	var content := FileAccess.get_file_as_string(path)
-	var parsed := JSON.parse_string(content)
+	var content: String = FileAccess.get_file_as_string(path)
+	var parsed: Variant = JSON.parse_string(content)
 	if typeof(parsed) != TYPE_DICTIONARY:
 		push_warning("StatsDB: format JSON inattendu pour %s" % path)
 		return {}
@@ -75,4 +74,3 @@ func _index_upgrades_by_scene() -> void:
 		var upgrade: Dictionary = upgrades.get(id, {})
 		if upgrade.has("scene"):
 			_upgrade_by_scene[upgrade["scene"]] = id
-

--- a/scripts/autoloads/stats_db.gd
+++ b/scripts/autoloads/stats_db.gd
@@ -3,12 +3,15 @@
 ## Charge et expose les stats centralisées (tours, upgrades, ennemis) depuis un JSON.
 extends Node
 
+# Constants
 const STATS_PATH: String = "res://assets/resources/configs/stats.json"
 
+# Private variables
 var _data: Dictionary = {}
 var _upgrade_by_scene: Dictionary = {}
 
 
+# Built-in functions
 func _ready() -> void:
 	_data = _load_json(STATS_PATH)
 	_index_upgrades_by_scene()
@@ -18,6 +21,7 @@ func _ready() -> void:
 	Log.trace(Log.Level.INFO, "StatsDB loaded: towers=%s, enemies=%s, upgrades=%s" % [towers_count, enemies_count, upgrades_count])
 
 
+# Public functions
 func get_tower(id: String) -> Dictionary:
 	return _data.get("towers", {}).get(id, {})
 
@@ -59,6 +63,7 @@ func load_packed_scene(path: String) -> PackedScene:
 	return res if res is PackedScene else null
 
 
+# Private functions
 func _load_json(path: String) -> Dictionary:
 	if not FileAccess.file_exists(path):
 		push_warning("StatsDB: fichier introuvable %s" % path)

--- a/scripts/autoloads/stats_db.gd
+++ b/scripts/autoloads/stats_db.gd
@@ -7,10 +7,12 @@ extends Node
 const STATS_PATH: String = "res://assets/resources/configs/stats.json"
 
 var _data: Dictionary = {}
+var _upgrade_by_scene: Dictionary = {}
 
 
 func _ready() -> void:
 	_data = _load_json(STATS_PATH)
+	_index_upgrades_by_scene()
 
 
 func get_tower(id: String) -> Dictionary:
@@ -37,6 +39,12 @@ func has_upgrade(id: String) -> bool:
 	return _data.get("upgrades", {}).has(id)
 
 
+func upgrade_id_from_scene(path: String) -> String:
+	if path.is_empty():
+		return ""
+	return _upgrade_by_scene.get(path, "")
+
+
 func has_enemy(id: String) -> bool:
 	return _data.get("enemies", {}).has(id)
 
@@ -58,4 +66,13 @@ func _load_json(path: String) -> Dictionary:
 		push_warning("StatsDB: format JSON inattendu pour %s" % path)
 		return {}
 	return parsed
+
+
+func _index_upgrades_by_scene() -> void:
+	_upgrade_by_scene.clear()
+	var upgrades: Dictionary = _data.get("upgrades", {})
+	for id in upgrades.keys():
+		var upgrade: Dictionary = upgrades.get(id, {})
+		if upgrade.has("scene"):
+			_upgrade_by_scene[upgrade["scene"]] = id
 

--- a/scripts/autoloads/stats_db.gd
+++ b/scripts/autoloads/stats_db.gd
@@ -1,0 +1,61 @@
+## © [2024] A7 Studio. All rights reserved. Trademark.
+##
+## Charge et expose les stats centralisées (tours, upgrades, ennemis) depuis un JSON.
+class_name StatsDB
+extends Node
+
+const STATS_PATH: String = "res://assets/resources/configs/stats.json"
+
+var _data: Dictionary = {}
+
+
+func _ready() -> void:
+	_data = _load_json(STATS_PATH)
+
+
+func get_tower(id: String) -> Dictionary:
+	return _data.get("towers", {}).get(id, {})
+
+
+func get_upgrade(id: String) -> Dictionary:
+	return _data.get("upgrades", {}).get(id, {})
+
+
+func get_enemy(id: String) -> Dictionary:
+	return _data.get("enemies", {}).get(id, {})
+
+
+func get_upgrade_ids_for_tower(id: String) -> Array:
+	return get_tower(id).get("upgrades", []) if has_tower(id) else []
+
+
+func has_tower(id: String) -> bool:
+	return _data.get("towers", {}).has(id)
+
+
+func has_upgrade(id: String) -> bool:
+	return _data.get("upgrades", {}).has(id)
+
+
+func has_enemy(id: String) -> bool:
+	return _data.get("enemies", {}).has(id)
+
+
+func load_packed_scene(path: String) -> PackedScene:
+	if path.is_empty():
+		return null
+	var res := load(path)
+	return res if res is PackedScene else null
+
+
+func _load_json(path: String) -> Dictionary:
+	if not FileAccess.file_exists(path):
+		push_warning("StatsDB: fichier introuvable %s" % path)
+		return {}
+	var content := FileAccess.get_file_as_string(path)
+	var parsed := JSON.parse_string(content)
+	if typeof(parsed) != TYPE_DICTIONARY:
+		push_warning("StatsDB: format JSON inattendu pour %s" % path)
+		return {}
+	return parsed
+

--- a/scripts/autoloads/stats_db.gd.uid
+++ b/scripts/autoloads/stats_db.gd.uid
@@ -1,0 +1,1 @@
+uid://yrajkjf7jbmv


### PR DESCRIPTION
Closes #179 

_Cette PR met en place un système de gestion des statistiques centralisé. L'objectif est de séparer l'équilibrage du jeu (données numériques) de la structure technique (scènes .tscn et scripts), facilitant ainsi les ajustements sans avoir à ouvrir chaque fichier individuellement._

### 🚀 Changements principaux

1. Base de données centralisée (stats.json)
Création d'un fichier assets/resources/configs/stats.json regroupant toutes les données :
Tours : Coût, cadence, portée, nombre de projectiles et statistiques des projectiles.
Ennemis : Points de vie (HP), vitesse, récompenses et statistiques spéciales (ex: BigDaddy).
Upgrades : Prix, modifications de stats et embranchements de l'arbre d'évolution.

2. Autoload StatsDB
Mise en place d'un singleton StatsDB qui charge le JSON au lancement.
Fournit des méthodes d'accès sécurisées (get_tower, get_enemy, get_upgrade) avec indexation automatique des upgrades par chemin de scène pour une récupération rapide dans les menus.

3. Injection au runtime
Tours & Ennemis : Les classes de base (ITower, IEnemy) injectent désormais les valeurs du JSON lors du _ready() via les propriétés tower_id et enemy_id.
BigDaddy : Mise à jour du script spécifique pour charger ses paramètres d'attaque (portée, délais, cadence) directement depuis le bloc extra du JSON.
Menu d'Upgrades : Le menu récupère dynamiquement les prix depuis la base de données au lieu de les lire dans les scènes exportées.

4. Nettoyage des fichiers .tscn et Scripts
Neutralisation des exports : Les variables de statistiques (HP, vitesse, coût, etc.) ne sont plus exportées dans l'inspecteur Godot pour éviter les doublons et la confusion.
Nettoyage des scènes : Les valeurs en dur ont été supprimées des fichiers .tscn. L'éditeur sert maintenant uniquement au visuel et aux collisions.

### 🛠️ Comment l'utiliser ?

Pour équilibrer le jeu : Modifiez simplement les valeurs dans assets/resources/configs/stats.json.
Pour ajouter une tour/ennemi :
Créez votre scène normalement.
Ajoutez une entrée dans le JSON avec un ID unique.
Remplissez le champ tower_id ou enemy_id dans l'inspecteur Godot avec cet ID.