### PR TITLE
Low health screen-edge indicator and damage camera shake

### DIFF
--- a/assets/resources/shaders/low_health_vignette.gdshader
+++ b/assets/resources/shaders/low_health_vignette.gdshader
@@ -1,10 +1,10 @@
 shader_type canvas_item;
 
 uniform float intensity : hint_range(0.0, 1.0) = 0.0;
-uniform float pulse_speed : hint_range(0.0, 10.0) = 2.0;
-uniform float noise_speed : hint_range(0.0, 10.0) = 5.0;
-uniform float edge_width : hint_range(0.0, 0.5) = 0.15;
-uniform vec4 base_color : source_color = vec4(0.8, 0.1, 0.1, 1.0);
+uniform float pulse_speed : hint_range(0.0, 10.0) = 1.5;
+uniform float noise_speed : hint_range(0.0, 10.0) = 3.0;
+uniform float edge_width : hint_range(0.0, 0.5) = 0.12;
+uniform vec4 base_color : source_color = vec4(0.8, 0.1, 0.1, 0.8);
 
 float hash(vec2 p) {
 	p = fract(p * vec2(123.34, 456.21));
@@ -21,20 +21,21 @@ void fragment() {
 	float edge_dist = min(dist_x, dist_y);
 	
 	// Create pixelated noise for the "organic/irregular" feel
-	vec2 pixel_uv = floor(uv * 128.0) / 128.0; // Pixelate the noise
+	// Increased resolution for smoother but still pixelated look
+	vec2 pixel_uv = floor(uv * 256.0) / 256.0; 
 	float n = hash(pixel_uv + floor(TIME * noise_speed));
 	
-	// Pulse effect
-	float pulse = 0.7 + 0.3 * sin(TIME * pulse_speed);
+	// Pulse effect - reduced amplitude and speed for more fluidity
+	float pulse = 0.5 + 0.25 * sin(TIME * pulse_speed);
 	
 	// Combine distance, noise, and intensity
 	float alpha = smoothstep(edge_width, 0.0, edge_dist);
-	alpha *= (0.6 + 0.4 * n); // Add texture/noise
+	alpha *= (0.7 + 0.3 * n); // Less aggressive noise
 	alpha *= intensity * pulse;
 	
-	// Ensure center is clear
-	float center_mask = smoothstep(0.0, edge_width * 2.0, edge_dist);
-	alpha *= (1.0 - center_mask * 0.5); // Subtly fade towards center
+	// Ensure center is clear with a smoother transition
+	float center_mask = smoothstep(0.0, edge_width * 1.5, edge_dist);
+	alpha *= (1.0 - center_mask * 0.7); 
 	
 	COLOR = vec4(base_color.rgb, alpha * base_color.a);
 }

--- a/assets/resources/shaders/low_health_vignette.gdshader
+++ b/assets/resources/shaders/low_health_vignette.gdshader
@@ -1,0 +1,40 @@
+shader_type canvas_item;
+
+uniform float intensity : hint_range(0.0, 1.0) = 0.0;
+uniform float pulse_speed : hint_range(0.0, 10.0) = 2.0;
+uniform float noise_speed : hint_range(0.0, 10.0) = 5.0;
+uniform float edge_width : hint_range(0.0, 0.5) = 0.15;
+uniform vec4 base_color : source_color = vec4(0.8, 0.1, 0.1, 1.0);
+
+float hash(vec2 p) {
+	p = fract(p * vec2(123.34, 456.21));
+	p += dot(p, p + 45.32);
+	return fract(p.x * p.y);
+}
+
+void fragment() {
+	vec2 uv = SCREEN_UV;
+	
+	// Distance from edges
+	float dist_x = min(uv.x, 1.0 - uv.x);
+	float dist_y = min(uv.y, 1.0 - uv.y);
+	float edge_dist = min(dist_x, dist_y);
+	
+	// Create pixelated noise for the "organic/irregular" feel
+	vec2 pixel_uv = floor(uv * 128.0) / 128.0; // Pixelate the noise
+	float n = hash(pixel_uv + floor(TIME * noise_speed));
+	
+	// Pulse effect
+	float pulse = 0.7 + 0.3 * sin(TIME * pulse_speed);
+	
+	// Combine distance, noise, and intensity
+	float alpha = smoothstep(edge_width, 0.0, edge_dist);
+	alpha *= (0.6 + 0.4 * n); // Add texture/noise
+	alpha *= intensity * pulse;
+	
+	// Ensure center is clear
+	float center_mask = smoothstep(0.0, edge_width * 2.0, edge_dist);
+	alpha *= (1.0 - center_mask * 0.5); // Subtly fade towards center
+	
+	COLOR = vec4(base_color.rgb, alpha * base_color.a);
+}

--- a/scenes/ui/menus/hud/hud.gd
+++ b/scenes/ui/menus/hud/hud.gd
@@ -28,6 +28,7 @@ const BUILD_SELECTION_MENU: PackedScene = preload("res://scenes/ui/menus/buildin
 @onready var skip_time_scale_button: TextureButton = $SkipMarginContainer/SkipButton
 @onready var build_selection_button: TextureButton = $BuildSelectionMarginContainer/BuildSelectionButton
 @onready var waves_rich_text_label: Label = %HUDVBoxContainer/CoinsWavesMarginContainer/CoinsWavesHBoxContainer/WavesTextureRect/MarginContainer/WavesLabel
+@onready var low_health_indicator: LowHealthIndicator = $LowHealthIndicator
 
 @onready var default_coins_text: String = coins_rich_text_label.text
 @onready var default_health_text: String = health_rich_text_label.text
@@ -251,6 +252,9 @@ func _update() -> void:
 	var health_ratio: float = float(ILevel.current_level.health) / max_health
 	if health_texture_progress_bar.material is ShaderMaterial:
 		health_texture_progress_bar.material.set_shader_parameter("health_percentage", health_ratio)
+	
+	if low_health_indicator:
+		low_health_indicator.update_health(health_ratio)
 	
 	var current_wave: int = ILevel.current_level.current_wave + 1
 	waves_rich_text_label.text = tr(default_waves_text) % current_wave

--- a/scenes/ui/menus/hud/hud.gd
+++ b/scenes/ui/menus/hud/hud.gd
@@ -214,6 +214,10 @@ func _spawn_coin_explosion(start_pos: Vector2) -> void:
 
 
 func _trigger_health_damage_effects() -> void:
+	# Camera shake
+	if Global.camera:
+		Global.camera.shake_camera_with_strength(15.0)
+	
 	# Flash effect via shader
 	if health_texture_progress_bar.material is ShaderMaterial:
 		var flash_tween = create_tween()

--- a/scenes/ui/menus/hud/hud.tscn
+++ b/scenes/ui/menus/hud/hud.tscn
@@ -15,6 +15,16 @@
 [ext_resource type="Texture2D" uid="uid://85fepmd06xnd" path="res://assets/ui/icons/Fast_Forward_Button.png" id="13_hn23h"]
 [ext_resource type="FontVariation" uid="uid://c5y1j2k3l4m5n" path="res://assets/ui/fonts/dotgothic/dotgothic_variation.tres" id="14_variation"]
 [ext_resource type="Shader" uid="uid://b6y7u8i9o0p1q" path="res://assets/resources/shaders/health_bar_scaling.gdshader" id="15_shader"]
+[ext_resource type="Script" uid="uid://lowhealthindicator" path="res://scenes/ui/menus/hud/low_health_indicator.gd" id="16_indicator"]
+[ext_resource type="Shader" uid="uid://lowhealthshader" path="res://assets/resources/shaders/low_health_vignette.gdshader" id="17_vignette"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_vignette"]
+shader = ExtResource("17_vignette")
+shader_parameter/intensity = 0.0
+shader_parameter/pulse_speed = 2.0
+shader_parameter/noise_speed = 5.0
+shader_parameter/edge_width = 0.15
+shader_parameter/base_color = Color(0.8, 0.1, 0.1, 1)
 
 [sub_resource type="Animation" id="1"]
 resource_name = "skip_active"
@@ -55,6 +65,17 @@ grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
 script = ExtResource("1_cuep3")
+
+[node name="LowHealthIndicator" type="ColorRect" parent="."]
+material = SubResource("ShaderMaterial_vignette")
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+script = ExtResource("16_indicator")
 
 [node name="PauseMarginContainer" type="MarginContainer" parent="."]
 layout_mode = 1

--- a/scenes/ui/menus/hud/low_health_indicator.gd
+++ b/scenes/ui/menus/hud/low_health_indicator.gd
@@ -1,0 +1,55 @@
+## © [2026] A7 Studio. All rights reserved. Trademark.
+
+class_name LowHealthIndicator
+extends ColorRect
+## Handles the visual feedback when player health is critically low.
+##
+## Displays a pulsing, pixelated red vignette around the screen edges.
+
+# Constants
+const CRITICAL_HEALTH_THRESHOLD: float = 0.25
+const FADE_DURATION: float = 0.5
+
+# Variables
+@onready var _is_active: bool = false
+var _intensity_tween: Tween
+
+# Built-in functions
+func _ready() -> void:
+	assert(material != null, "LowHealthIndicator: material is missing")
+	# Ensure it covers the whole screen
+	set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	
+	# Initial state: hidden/transparent
+	material.set_shader_parameter("intensity", 0.0)
+	hide()
+
+
+# Public functions
+## Updates the indicator based on current health ratio.
+## [param health_ratio] The current health as a value between 0.0 and 1.0.
+func update_health(health_ratio: float) -> void:
+	var should_be_active: bool = health_ratio <= CRITICAL_HEALTH_THRESHOLD
+	
+	if should_be_active != _is_active:
+		_toggle_effect(should_be_active)
+
+
+# Private functions
+func _toggle_effect(active: bool) -> void:
+	_is_active = active
+	
+	if _intensity_tween:
+		_intensity_tween.kill()
+	
+	_intensity_tween = create_tween()
+	
+	if active:
+		show()
+		_intensity_tween.tween_property(material, "shader_parameter/intensity", 1.0, FADE_DURATION)\
+			.set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
+	else:
+		_intensity_tween.tween_property(material, "shader_parameter/intensity", 0.0, FADE_DURATION)\
+			.set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN)
+		_intensity_tween.finished.connect(hide)

--- a/scenes/ui/menus/hud/low_health_indicator.gd.uid
+++ b/scenes/ui/menus/hud/low_health_indicator.gd.uid
@@ -1,0 +1,1 @@
+uid://bobwx2yvj4bf4


### PR DESCRIPTION
Implemented a retro-inspired, pixelated red vignette that pulses when player health is below 25%. The effect features dynamic noise and smooth transitions to enhance tension without obstructing gameplay. Additionally, added a camera shake effect triggered upon taking damage to improve hit feedback.