### PR TITLE
Make the map not interactive on the result screen

### DIFF
--- a/scenes/gameplay/entities/building_placement/build_placement.gd
+++ b/scenes/gameplay/entities/building_placement/build_placement.gd
@@ -87,6 +87,9 @@ func _ready() -> void:
 		SignalUtil.connects(level_signals)
 
 func _unhandled_input(event: InputEvent) -> void:
+	if Global.paused:
+		return
+
 	if _state == CursorState.BUILD:
 		_state_build_input(event)
 

--- a/scenes/gameplay/entities/tower/i_tower.gd
+++ b/scenes/gameplay/entities/tower/i_tower.gd
@@ -659,11 +659,15 @@ func _on_area_2d_area_exited(area: Area2D) -> void:
 		area.queue_free()
 
 func _on_tower_hover_box_mouse_entered() -> void:
+	if Global.paused:
+		return
 	if _menu_open:
 		return
 	show_range(true)
 
 func _on_tower_hover_box_mouse_exited() -> void:
+	if Global.paused:
+		return
 	if _menu_open:
 		return
 	show_range(false)
@@ -677,6 +681,8 @@ func _on_timer_timeout() -> void:
 
 func _on_tower_pressed() -> void:
 	Log.trace(Log.Level.DEBUG, "Tower Pressed")
+	if Global.paused:
+		return
 
 	if state != TowerState.ACTIVE:
 		return

--- a/scenes/gameplay/world/level/i_level.gd
+++ b/scenes/gameplay/world/level/i_level.gd
@@ -173,6 +173,7 @@ func _on_state_wave(_args = []) -> bool:
 
 func _on_level_end(_args = []) -> void:
 	clock.stop()
+	Global.paused = true
 
 	end_time = Time.get_unix_time_from_system()
 	var end_game_menu_instance: EndGame = ScenesLoader.END_GAME_MENU.instantiate()


### PR DESCRIPTION
Prevent the camera being movable during the result screen.