### PR TITLE
Fix the slow trap when placed next to each other.

### DIFF
--- a/scenes/gameplay/entities/trap/traps/bat_04.gd
+++ b/scenes/gameplay/entities/trap/traps/bat_04.gd
@@ -4,26 +4,37 @@
 class_name Bat04
 extends ITrap
 
+const _SLOW_BASE_SPEED_KEY: StringName = &"bat_04_slow_base_speed"
+const _SLOW_STACK_KEY: StringName = &"bat_04_slow_stack_count"
+
 ## The slow effect percentage (0.5 = 50% slower)
 @export var slow_amount: float = 0.75
-
-## Dictionary to store original speeds
-var original_speeds: Dictionary = {}
 
 func _ready() -> void:
 	super()
 
 func apply_effect(enemy: IEnemy) -> void:
-	if not enemy in original_speeds:
-		original_speeds[enemy] = enemy.speed
+	var slow_stack_count: int = int(enemy.get_meta(_SLOW_STACK_KEY, 0))
+	if slow_stack_count == 0:
+		enemy.set_meta(_SLOW_BASE_SPEED_KEY, enemy.speed)
 		enemy.speed *= (1.0 - slow_amount)
 		enemy.push_slow_visual()
+	enemy.set_meta(_SLOW_STACK_KEY, slow_stack_count + 1)
 
 func remove_effect(enemy: IEnemy) -> void:
-	if enemy in original_speeds:
-		enemy.speed = original_speeds[enemy]
-		original_speeds.erase(enemy)
+	var slow_stack_count: int = int(enemy.get_meta(_SLOW_STACK_KEY, 0))
+	if slow_stack_count <= 0:
+		return
+
+	slow_stack_count -= 1
+	if slow_stack_count == 0:
+		var base_speed: float = float(enemy.get_meta(_SLOW_BASE_SPEED_KEY, enemy.speed))
+		enemy.speed = base_speed
+		enemy.remove_meta(_SLOW_BASE_SPEED_KEY)
 		enemy.pop_slow_visual()
+		enemy.remove_meta(_SLOW_STACK_KEY)
+	else:
+		enemy.set_meta(_SLOW_STACK_KEY, slow_stack_count)
 
 func _apply_trap_stats_extension(_base: Dictionary) -> void:
 	if _base.has("slow_amount"):


### PR DESCRIPTION
This pull request refactors the way the Bat04 trap applies and removes its slow effect to enemies. Instead of using a shared dictionary to track original speeds, it now uses per-enemy metadata, which improves data encapsulation and handles stacking slow effects more robustly.

Effect stacking and metadata handling:

* Replaced the global `original_speeds` dictionary with per-enemy metadata keys (`bat_04_slow_base_speed` and `bat_04_slow_stack_count`) to store each enemy's base speed and the number of slow effect stacks.
* Updated `apply_effect` to handle stacking: only the first application stores the base speed and applies the slow, while subsequent stacks increment a counter.
* Updated `remove_effect` to decrement the slow stack count, only restoring the enemy's speed and removing the visual effect when all stacks are removed.…nemy speed management