### PR TITLE
Refactor level end handling and improve UI feedback

### DIFF
--- a/scenes/gameplay/world/level/i_level.gd
+++ b/scenes/gameplay/world/level/i_level.gd
@@ -49,6 +49,11 @@ var _time_scale_before_pause: float = 1.0
 @onready var popup_spawner: PopupSpawner = $PopupSpawner
 
 # core
+func _ready() -> void:
+	assert(clock != null, "clock node not found")
+	assert(popup_spawner != null, "popup_spawner node not found")
+
+
 ## Custom ticker callback
 func _process_tick() -> void:
 	assert(state_machine)
@@ -68,7 +73,7 @@ func start_level() -> void:
 	await get_tree().create_timer(POST_SPECIAL_TILE_INTRO_DELAY_SECONDS).timeout
 	state_machine.toggle_initial_state()
 	start_time = Time.get_unix_time_from_system()
-	popup_spawner.wave("Wave %s" % [current_wave+1])
+	popup_spawner.wave(tr("Wave %s") % [current_wave + 1])
 
 	clock.subscribe(_process_tick, 5)
 	clock.start()
@@ -137,7 +142,7 @@ func _next_wave() -> void:
 		state_machine.toggle_state(STATE_VICTORY)
 		return
 	current_wave += 1
-	popup_spawner.wave("Wave %s" % [current_wave+1])
+	popup_spawner.wave(tr("Wave %s") % [current_wave + 1])
 	state_machine.toggle_state(STATE_WAVE % current_wave)
 
 
@@ -171,13 +176,13 @@ func _on_state_wave(_args = []) -> bool:
 
 	return true
 
-func _on_level_end(_args = []) -> void:
+func _on_level_end(victory: bool, _args = []) -> void:
 	clock.stop()
 
 	end_time = Time.get_unix_time_from_system()
 	var end_game_menu_instance: EndGame = ScenesLoader.END_GAME_MENU.instantiate()
 	Global.ui.add_child(end_game_menu_instance)
-	end_game_menu_instance.init(true)
+	end_game_menu_instance.init(victory)
 	state_machine.toggle_state(STATE_END)
 
 
@@ -185,14 +190,14 @@ func _on_state_victory(_args = []) -> bool:
 	Log.trace(Log.Level.INFO, "Entering VICTORY state.")
 	ChallengeManager.check_victory_conditions()
 
-	_on_level_end()
+	_on_level_end(true)
 	return true
 
 
 func _on_state_defeat(_args = []) -> bool:
 	Log.trace(Log.Level.INFO, "Entering DEFEAT state.")
 
-	_on_level_end()
+	_on_level_end(false)
 	return true
 
 

--- a/scenes/ui/menus/end_game/end_game.gd
+++ b/scenes/ui/menus/end_game/end_game.gd
@@ -10,12 +10,18 @@ extends Control
 # Constants
 const CONDITION_DONE: Texture2D = preload("res://assets/ui/icons/Star.png")
 const CONDITION_TODO: Texture2D = preload("res://assets/ui/icons/Star_Empty.png")
+const DEFEAT_TITLE_COLOR: Color = Color(0.85, 0.2, 0.2, 1.0)
+const NORMAL_CHALLENGE_COLOR: Color = Color.WHITE
+const TINT_DEFAULT: Color = Color.WHITE
+const TINT_FAILED: Color = Color(1.0, 0.35, 0.35, 1.0)
+const VICTORY_TITLE_COLOR: Color = Color(0.364706, 0.847059, 0.364706, 1)
 
 
 # Variables
 var elapsed_time_minutes: int
 var elapsed_time_seconds: int
 var elapsed_time_text: String
+var _is_victory: bool = true
 
 @onready var challenges_vbox: VBoxContainer = $GUIMarginContainer/BackgroundTextureRect/ContentMarginContainer/VBoxContainerMain/ChallengesVBoxContainer
 @onready var end_game_image: TextureRect = $GUIMarginContainer/BackgroundTextureRect/ContentMarginContainer/VBoxContainerMain/ResultIconTextureRect
@@ -52,6 +58,7 @@ func _ready() -> void:
 # Public functions
 ## Initializes the end game screen with victory or defeat state.
 func init(victory: bool) -> void:
+	_is_victory = victory
 	var build_menu := Global.ui.get_node_or_null("BuildSelection")
 	if build_menu:
 		build_menu.queue_free()
@@ -73,10 +80,12 @@ func init(victory: bool) -> void:
 
 	if victory:
 		title_label.text = tr("ENDGAMEMENU.LEVEL.TITLE.WIN")
+		title_label.add_theme_color_override("font_color", VICTORY_TITLE_COLOR)
 		end_game_image.texture = ResourceLoader.load("res://assets/ui/icons/Victory Gold.svg")
 		ProgressionManager.complete_level(ILevel.current_level.level_id)
 	else:
 		title_label.text = tr("ENDGAMEMENU.LEVEL.TITLE.LOOSE")
+		title_label.add_theme_color_override("font_color", DEFEAT_TITLE_COLOR)
 		end_game_image.texture = ResourceLoader.load("res://assets/ui/icons/Defeat.svg")
 		next_button.get_parent().visible = false
 
@@ -98,12 +107,20 @@ func _display_challenges() -> void:
 		icon_rect.custom_minimum_size = Vector2(30, 30)
 		icon_rect.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
 		icon_rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
-		icon_rect.texture = CONDITION_DONE if challenge.is_completed else CONDITION_TODO
+		var is_done: bool = challenge.is_completed
+		var is_failed_visual: bool = challenge.is_failed or (not _is_victory and not is_done)
+		if is_failed_visual:
+			icon_rect.texture = CONDITION_DONE
+			icon_rect.modulate = TINT_FAILED
+		else:
+			icon_rect.texture = CONDITION_DONE if is_done else CONDITION_TODO
+			icon_rect.modulate = TINT_DEFAULT
 
 		var label := Label.new()
 		label.text = tr(challenge.title) + ": " + tr(challenge.description)
 		label.add_theme_font_override("font", load("res://assets/ui/fonts/dotgothic/DotGothic16-Regular.ttf"))
 		label.add_theme_font_size_override("font_size", 20)
+		label.add_theme_color_override("font_color", NORMAL_CHALLENGE_COLOR)
 
 		hbox.add_child(icon_rect)
 		hbox.add_child(label)


### PR DESCRIPTION
This pull request improves the clarity and feedback of the end-game experience and wave announcements in the game. It introduces clearer victory/defeat distinction in the end-game UI, enhances challenge status visualization, and internationalizes wave announcements. It also adds safety checks for critical nodes during level initialization.

**End Game UI Improvements:**
* The `end_game.gd` UI now visually distinguishes between victory and defeat by changing the title color and result icon depending on the outcome. The defeat state hides the "next" button, and both states use color-coded titles for clarity. [[1]](diffhunk://#diff-fd925d395ba60d9a057a936926cbc7810e04b6ed4cc043e2c0e934a6c51818f8R13-R24) [[2]](diffhunk://#diff-fd925d395ba60d9a057a936926cbc7810e04b6ed4cc043e2c0e934a6c51818f8R83-R88)
* Challenge icons now visually indicate failed challenges with a red tint, and all challenge labels use a consistent font color. Failed challenges are more clearly communicated, especially in defeat scenarios.

**Level Logic and Internationalization:**
* The `i_level.gd` script now passes a `victory` flag to the end-game menu, ensuring the UI reflects the correct game outcome. [[1]](diffhunk://#diff-9007c516e306164231ecb7d243743e816b08193c1414af4e02eff78ca137c636L174-R200) [[2]](diffhunk://#diff-fd925d395ba60d9a057a936926cbc7810e04b6ed4cc043e2c0e934a6c51818f8R61)
* Wave announcements are now localized using the `tr()` function, supporting translation for different languages. [[1]](diffhunk://#diff-9007c516e306164231ecb7d243743e816b08193c1414af4e02eff78ca137c636L71-R76) [[2]](diffhunk://#diff-9007c516e306164231ecb7d243743e816b08193c1414af4e02eff78ca137c636L140-R145)

**Code Safety:**
* Added assertions in the `_ready()` function of `i_level.gd` to ensure required nodes (`clock` and `popup_spawner`) are present, helping to catch setup errors early.…ry/defeat states