### PR TITLE
Refactor building placement and improve HUD menu behavior

### DIFF
--- a/scenes/gameplay/entities/building_placement/build_placement.gd
+++ b/scenes/gameplay/entities/building_placement/build_placement.gd
@@ -110,11 +110,15 @@ func change_state(new_state: CursorState, args: Array = []) -> void:
 			# Re-enable on-map tower UI (buttons / hover)
 			_set_placed_tower_ui_enabled(true)
 		CursorState.BUILD:
+			assert(args.size() == 1)
+			assert(args[0] is IBuilding)
+			if _state == CursorState.BUILD:
+				_state_build(args[0], true)
+				_update()
+				return
 			if _state != CursorState.IDLE:
 				Log.trace(Log.Level.WARN, "Cannot enter BUILD state: current state is not IDLE")
 				return
-			assert(args.size() == 1)
-			assert(args[0] is IBuilding)
 
 			trigger_state_build.emit()
 			_state = new_state
@@ -387,17 +391,22 @@ func _set_placed_tower_ui_enabled(enabled: bool) -> void:
 				hover_area.input_pickable = enabled
 
 ## Build-mode frame: follow cursor, tint preview, validate tile.
-func _state_build(template: Node2D = null) -> void:
+## [param template] New building template to preview.
+## [param keep_current_cursor_position] Keep current selected tile when replacing preview.
+func _state_build(template: Node2D = null, keep_current_cursor_position: bool = false) -> void:
 	if template:
 		var tpl: IBuilding = template as IBuilding
-		var initial_global: Vector2 = _get_initial_build_position()
-		if tm_ref:
-			var origin_cell: Vector2i = tm_ref.local_to_map(tm_ref.to_local(initial_global))
-			var best_cell: Vector2i = _find_nearest_valid_build_cell(origin_cell, tpl)
-			_set_cursor_position(tm_ref.map_to_local(best_cell))
-		else:
-			_set_cursor_position(initial_global)
+		if not keep_current_cursor_position:
+			var initial_global: Vector2 = _get_initial_build_position()
+			if tm_ref:
+				var origin_cell: Vector2i = tm_ref.local_to_map(tm_ref.to_local(initial_global))
+				var best_cell: Vector2i = _find_nearest_valid_build_cell(origin_cell, tpl)
+				_set_cursor_position(tm_ref.map_to_local(best_cell))
+			else:
+				_set_cursor_position(initial_global)
 
+		if _preview_building:
+			_preview_building.queue_free()
 		_preview_building = template.duplicate() as IBuilding
 		_preview_building.enter_build_preview()
 		_preview_building.position = cursor.position - Vector2(0, _preview_building.get_placement_vertical_offset())

--- a/scenes/gameplay/entities/building_placement/build_placement.gd
+++ b/scenes/gameplay/entities/building_placement/build_placement.gd
@@ -139,8 +139,11 @@ func change_state(new_state: CursorState, args: Array = []) -> void:
 
 ## Removes a cell from the invalid cells list so a building can be placed there again.
 func remove_invalid_cell(tm_pos: Vector2i) -> void:
-	if tm_pos in _invalid_cells:
+	var removed_any: bool = false
+	while tm_pos in _invalid_cells:
 		_invalid_cells.erase(tm_pos)
+		removed_any = true
+	if removed_any:
 		Log.trace(Log.Level.INFO, "Cell {0} is now free for building".format([tm_pos]))
 
 func _build() -> void:
@@ -184,7 +187,7 @@ func _build() -> void:
 	if new_entity is IBuilding:
 		ChallengeManager.notify_building_placed(new_entity as IBuilding)
 
-	_invalid_cells.append(tm_pos)
+	add_invalid_cell(tm_pos)
 	ILevel.current_level.coins -= _preview_building.cost
 
 	_cancel_build()

--- a/scenes/gameplay/entities/trap/i_trap.gd
+++ b/scenes/gameplay/entities/trap/i_trap.gd
@@ -46,6 +46,11 @@ var active_affected_enemies: Dictionary
 ## Dictionary to track remaining effect duration for dead enemies (LIMITED type)
 var remaining_effects: Array[float] = []
 
+## Tile position used by the placement system occupancy checks.
+var tile_pos: Vector2i = Vector2i.ZERO
+
+var _is_registered_in_placement_system: bool = false
+
 ## The area 2D node for the trap to detect enemies
 @onready var area_2d: Area2D = $Area2D
 
@@ -64,6 +69,16 @@ func _ready() -> void:
 	SignalUtil.connects(signals)
 	current_durability = max_durability
 	active_affected_enemies = {}
+	if state == TrapState.ACTIVE:
+		_register_with_cursor()
+
+func _exit_tree() -> void:
+	if not _is_registered_in_placement_system:
+		return
+	var placement_system: BuildPlacement = Global.get("cursor") as BuildPlacement
+	if placement_system:
+		placement_system.remove_invalid_cell(tile_pos)
+	_is_registered_in_placement_system = false
 
 func _process(delta: float) -> void:
 	if Global.paused:
@@ -144,7 +159,14 @@ func get_trap_type() -> String:
 		_:
 			return ""
 
-# private
+## Override these methods in specific trap implementations.
+func apply_effect(_enemy: IEnemy) -> void:
+	pass
+
+func remove_effect(_enemy: IEnemy) -> void:
+	pass
+
+## Private API
 ## Subclasses read extra [code]base[/code] keys (e.g. [code]damage[/code], [code]slow_amount[/code]).
 func _apply_trap_stats_extension(_base: Dictionary) -> void:
 	pass
@@ -177,7 +199,18 @@ func _on_enemy_die(enemy: IEnemy) -> void:
 
 func _update_z_index() -> void:
 	var y_position := int(global_position.y)
-	z_index = (y_position / 2) - 10
+	z_index = int(y_position / 2.0) - 10
+
+func _register_with_cursor() -> void:
+	if not is_inside_tree():
+		return
+	var placement_system: BuildPlacement = Global.get("cursor") as BuildPlacement
+	if not placement_system:
+		return
+	if tile_pos == Vector2i.ZERO and placement_system.tm_ref:
+		tile_pos = placement_system.tm_ref.local_to_map(placement_system.tm_ref.to_local(global_position))
+	placement_system.add_invalid_cell(tile_pos)
+	_is_registered_in_placement_system = true
 
 func _get_enemy_from_overlap(overlap: Node2D) -> IEnemy:
 	# We want traps to trigger based on the zombie "feet" zone only.
@@ -192,7 +225,7 @@ func _get_enemy_from_overlap(overlap: Node2D) -> IEnemy:
 
 	return null
 
-# signal
+## Signal handlers
 func _on_area_2d_body_entered(body: Node2D) -> void:
 	if state != TrapState.ACTIVE:
 		return
@@ -222,10 +255,3 @@ func _on_area_2d_body_exited(body: Node2D) -> void:
 		if enemy in active_affected_enemies:
 			remove_effect(enemy)
 			active_affected_enemies.erase(enemy)
-
-## Override these methods in specific trap implementations
-func apply_effect(_enemy: IEnemy) -> void:
-	pass
-
-func remove_effect(_enemy: IEnemy) -> void:
-	pass

--- a/scenes/ui/menus/hud/hud.gd
+++ b/scenes/ui/menus/hud/hud.gd
@@ -120,6 +120,11 @@ func _on_challenges_button_pressed() -> void:
 
 func _on_pause_button_pressed() -> void:
 	if not Global.paused and ILevel.current_level != null:
+		var build_selection_menu: Node = Global.ui.get_node_or_null("BuildSelection")
+		if build_selection_menu != null:
+			build_selection_menu.queue_free()
+			build_selection_button.button_pressed = false
+
 		# Use Godot's built-in pause system
 		get_tree().paused = true
 		Global.paused = true


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes related to the building placement system and trap management, focusing on robustness, UI consistency, and proper occupancy handling. The main changes ensure that traps correctly register and unregister their occupied tiles, improve the state transition logic for building placement, and enhance UI behavior when pausing the game.

**Building Placement and State Management:**
- Improved the `change_state` method in `build_placement.gd` to handle repeated transitions into the `BUILD` state more robustly, allowing for preview replacement without requiring an idle state.
- Enhanced the `_state_build` method to support keeping the current cursor position when updating the building preview, and ensured the previous preview is freed to prevent resource leaks. [[1]](diffhunk://#diff-dfa15a1fdd8d4b23c7201d415f81f5448e3258e1260530b395b7fe4aadca0fecL387-R399) [[2]](diffhunk://#diff-dfa15a1fdd8d4b23c7201d415f81f5448e3258e1260530b395b7fe4aadca0fecR408-R409)

**Trap Registration and Occupancy:**
- Added `tile_pos` and `_is_registered_in_placement_system` to `i_trap.gd`, and implemented `_register_with_cursor` and `_exit_tree` to automatically register traps with the placement system on activation and unregister them on removal, ensuring correct occupancy tracking. [[1]](diffhunk://#diff-8e3b669ccfbfc3411519d1423833535f67f86a3f54f91c880f869e3867480213R49-R53) [[2]](diffhunk://#diff-8e3b669ccfbfc3411519d1423833535f67f86a3f54f91c880f869e3867480213R72-R81) [[3]](diffhunk://#diff-8e3b669ccfbfc3411519d1423833535f67f86a3f54f91c880f869e3867480213L180-R213)
- Modified `remove_invalid_cell` in `build_placement.gd` to remove all instances of a cell from the invalid list, preventing stale occupancy.

**UI and Pause Handling:**
- Updated the pause button handler in `hud.gd` to close the build selection menu and reset its button state when pausing, ensuring UI consistency.

**Code Organization and Cleanup:**
- Moved trap effect methods (`apply_effect`, `remove_effect`) to a more appropriate section and clarified their override intent in trap subclasses. [[1]](diffhunk://#diff-8e3b669ccfbfc3411519d1423833535f67f86a3f54f91c880f869e3867480213L147-R169) [[2]](diffhunk://#diff-8e3b669ccfbfc3411519d1423833535f67f86a3f54f91c880f869e3867480213L225-L231)
- Improved comments and signal handler organization for clarity in `i_trap.gd`.

These changes collectively improve the reliability of building placement, especially around traps, and enhance the user experience during gameplay and UI interactions.