### PR TITLE
Implement categorized tabs for Towers and Traps in build menu

### DIFF
--- a/assets/translations/translations.csv
+++ b/assets/translations/translations.csv
@@ -96,6 +96,8 @@ ARMORY.RESET_SPENT_STARS,Reset,Réinitialiser
 ARMORY.RESET_STARS_CONFIRM,Are you sure you want to reset the armory?,Êtes-vous sûr de vouloir réinitialiser l'armurerie ?
 ARMORY.RESET_CONFIRM_OK,OK,Confirmer
 ARMORY.RESET_CANCEL,Cancel,Annuler
+BUILD.TAB.TOWERS,Towers,Tours
+BUILD.TAB.TRAPS,Traps,Pièges
 ARMORY.STAR_COST,%d stars,%d étoiles
 ARMORY.BUY,Buy,Acheter
 ARMORY.BUY_BLOCKED,BLOCKED,BLOQUÉ

--- a/scenes/ui/menus/building_selection/build_selection.gd
+++ b/scenes/ui/menus/building_selection/build_selection.gd
@@ -4,9 +4,15 @@
 class_name BuildSelection
 extends Control
 
+enum Tab { TOWERS, TRAPS }
+
 ## Row of [BuildCard] instances.
-@onready var construction_menu: HBoxContainer = $MarginContainer/BackgroundTextureRect/BuildListMarginContainer/HBoxContainer
+@onready var construction_menu: HBoxContainer = $MarginContainer/VBoxContainer/BackgroundTextureRect/BuildListMarginContainer/HBoxContainer
 @onready var construction_anim_player: AnimationPlayer = $AnimationPlayer
+@onready var tower_tab_button: Button = $MarginContainer/VBoxContainer/TabsHBox/TowerTabButton
+@onready var trap_tab_button: Button = $MarginContainer/VBoxContainer/TabsHBox/TrapTabButton
+
+var _current_tab: Tab = Tab.TOWERS
 
 func _exit_tree() -> void:
 	if ILevel.current_level and ILevel.current_level.stats_updated.is_connected(_on_level_stats_updated):
@@ -21,6 +27,8 @@ func _process(_delta: float) -> void:
 func _ready() -> void:
 	assert(construction_menu != null, "construction_menu node not found")
 	assert(construction_anim_player != null, "construction_anim_player node not found")
+	assert(tower_tab_button != null, "tower_tab_button node not found")
+	assert(trap_tab_button != null, "trap_tab_button node not found")
 
 	construction_anim_player.animation_finished.connect(
 	func(_name: String) -> void:
@@ -29,8 +37,14 @@ func _ready() -> void:
 	)
 	construction_menu.visible = true
 
+	tower_tab_button.pressed.connect(_on_tab_pressed.bind(Tab.TOWERS))
+	trap_tab_button.pressed.connect(_on_tab_pressed.bind(Tab.TRAPS))
+
 	if ILevel.current_level:
 		ILevel.current_level.stats_updated.connect(_on_level_stats_updated)
+	
+	_update_tab_visuals()
+	_refresh_construction_cards()
 
 
 # Public functions
@@ -51,14 +65,37 @@ func toggle_build_menu() -> void:
 
 # Private functions
 
-## Re-runs [method BuildCard.update] on every card when [signal ILevel.stats_updated] fires (e.g. coins).
 func _on_level_stats_updated() -> void:
+	_refresh_construction_cards()
+
+
+func _on_tab_pressed(tab: Tab) -> void:
+	if _current_tab == tab:
+		return
+	_current_tab = tab
+	_update_tab_visuals()
 	_refresh_construction_cards()
 
 
 ## Refreshes price / disabled state on all build cards (coins may have changed).
 func _refresh_construction_cards() -> void:
 	for aspect in construction_menu.get_children():
-		for card in aspect.get_children():
-			if card is BuildCard:
-				(card as BuildCard).update()
+		var card: BuildCard = aspect.get_child(0) as BuildCard
+		if card:
+			var is_tower: bool = card._entity is ITower
+			var is_trap: bool = card._entity is ITrap
+			
+			var should_be_visible: bool = false
+			if _current_tab == Tab.TOWERS and is_tower:
+				should_be_visible = true
+			elif _current_tab == Tab.TRAPS and is_trap:
+				should_be_visible = true
+			
+			aspect.visible = should_be_visible
+			if should_be_visible:
+				card.update()
+
+
+func _update_tab_visuals() -> void:
+	tower_tab_button.disabled = (_current_tab == Tab.TOWERS)
+	trap_tab_button.disabled = (_current_tab == Tab.TRAPS)

--- a/scenes/ui/menus/building_selection/build_selection.tscn
+++ b/scenes/ui/menus/building_selection/build_selection.tscn
@@ -42,16 +42,41 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_constants/margin_left = 4
-theme_override_constants/margin_top = 15
+theme_override_constants/margin_top = 0
 theme_override_constants/margin_bottom = 4
 
-[node name="BackgroundTextureRect" type="TextureRect" parent="MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
 layout_mode = 2
+theme_override_constants/separation = -5
+
+[node name="TabsHBox" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 0
+theme_override_constants/separation = 10
+alignment = 1
+
+[node name="TowerTabButton" type="Button" parent="MarginContainer/VBoxContainer/TabsHBox"]
+layout_mode = 2
+size_flags_vertical = 4
+focus_mode = 0
+theme_override_font_sizes/font_size = 14
+text = "BUILD.TAB.TOWERS"
+
+[node name="TrapTabButton" type="Button" parent="MarginContainer/VBoxContainer/TabsHBox"]
+layout_mode = 2
+size_flags_vertical = 4
+focus_mode = 0
+theme_override_font_sizes/font_size = 14
+text = "BUILD.TAB.TRAPS"
+
+[node name="BackgroundTextureRect" type="TextureRect" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
 texture = ExtResource("2_tcv0b")
 expand_mode = 1
 flip_h = true
 
-[node name="BuildListMarginContainer" type="MarginContainer" parent="MarginContainer/BackgroundTextureRect"]
+[node name="BuildListMarginContainer" type="MarginContainer" parent="MarginContainer/VBoxContainer/BackgroundTextureRect"]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -64,40 +89,40 @@ theme_override_constants/margin_top = 7
 theme_override_constants/margin_right = 32
 theme_override_constants/margin_bottom = 7
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/BackgroundTextureRect/BuildListMarginContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/BackgroundTextureRect/BuildListMarginContainer"]
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 3
 theme_override_constants/separation = 150
 alignment = 1
 
-[node name="Bat01AspectRatioContainer" type="AspectRatioContainer" parent="MarginContainer/BackgroundTextureRect/BuildListMarginContainer/HBoxContainer"]
+[node name="Bat01AspectRatioContainer" type="AspectRatioContainer" parent="MarginContainer/VBoxContainer/BackgroundTextureRect/BuildListMarginContainer/HBoxContainer"]
 layout_mode = 2
 stretch_mode = 1
 
-[node name="BuildCardBat01" parent="MarginContainer/BackgroundTextureRect/BuildListMarginContainer/HBoxContainer/Bat01AspectRatioContainer" instance=ExtResource("3_60iow")]
+[node name="BuildCardBat01" parent="MarginContainer/VBoxContainer/BackgroundTextureRect/BuildListMarginContainer/HBoxContainer/Bat01AspectRatioContainer" instance=ExtResource("3_60iow")]
 layout_mode = 2
 entity = ExtResource("7_bat01")
 
-[node name="Bat02AspectRatioContainer" type="AspectRatioContainer" parent="MarginContainer/BackgroundTextureRect/BuildListMarginContainer/HBoxContainer"]
+[node name="Bat02AspectRatioContainer" type="AspectRatioContainer" parent="MarginContainer/VBoxContainer/BackgroundTextureRect/BuildListMarginContainer/HBoxContainer"]
 layout_mode = 2
 stretch_mode = 1
 
-[node name="BuildCardBat02" parent="MarginContainer/BackgroundTextureRect/BuildListMarginContainer/HBoxContainer/Bat02AspectRatioContainer" instance=ExtResource("5_aw86t")]
+[node name="BuildCardBat02" parent="MarginContainer/VBoxContainer/BackgroundTextureRect/BuildListMarginContainer/HBoxContainer/Bat02AspectRatioContainer" instance=ExtResource("5_aw86t")]
 layout_mode = 2
 
-[node name="Bat03AspectRatioContainer" type="AspectRatioContainer" parent="MarginContainer/BackgroundTextureRect/BuildListMarginContainer/HBoxContainer"]
-layout_mode = 2
-stretch_mode = 1
-
-[node name="BuildCardBat03" parent="MarginContainer/BackgroundTextureRect/BuildListMarginContainer/HBoxContainer/Bat03AspectRatioContainer" instance=ExtResource("8_bat_03_card")]
-layout_mode = 2
-
-[node name="Bat04AspectRatioContainer" type="AspectRatioContainer" parent="MarginContainer/BackgroundTextureRect/BuildListMarginContainer/HBoxContainer"]
+[node name="Bat03AspectRatioContainer" type="AspectRatioContainer" parent="MarginContainer/VBoxContainer/BackgroundTextureRect/BuildListMarginContainer/HBoxContainer"]
 layout_mode = 2
 stretch_mode = 1
 
-[node name="BuildCardBat04" parent="MarginContainer/BackgroundTextureRect/BuildListMarginContainer/HBoxContainer/Bat04AspectRatioContainer" instance=ExtResource("11_bat_04_card")]
+[node name="BuildCardBat03" parent="MarginContainer/VBoxContainer/BackgroundTextureRect/BuildListMarginContainer/HBoxContainer/Bat03AspectRatioContainer" instance=ExtResource("8_bat_03_card")]
+layout_mode = 2
+
+[node name="Bat04AspectRatioContainer" type="AspectRatioContainer" parent="MarginContainer/VBoxContainer/BackgroundTextureRect/BuildListMarginContainer/HBoxContainer"]
+layout_mode = 2
+stretch_mode = 1
+
+[node name="BuildCardBat04" parent="MarginContainer/VBoxContainer/BackgroundTextureRect/BuildListMarginContainer/HBoxContainer/Bat04AspectRatioContainer" instance=ExtResource("11_bat_04_card")]
 layout_mode = 2
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]


### PR DESCRIPTION
## Summary
Implemented a tab-based navigation system in the build menu to separate Towers and Traps. This change improves UI organization by preventing different entity types from being mixed in a single list, making it easier for players to find and select specific buildings.

## Key Changes
- **UI Organization**: Introduced a `VBoxContainer` hierarchy in the build menu to host categorized tabs above the construction list.
- **Tabbed Navigation**:
  - Added "Tours" (Towers) and "Pièges" (Traps) buttons with dynamic state management.
  - The active tab is visually disabled to indicate selection.
  - Reduced tab button font size to 14 for a more compact and integrated look.
- **Dynamic Filtering**: 
  - Implemented logic in `build_selection.gd` to automatically sort entities based on their class (`ITower` vs `ITrap`).
  - The menu now defaults to the Towers tab upon opening.
- **Internationalization**: Integrated `BUILD.TAB.TOWERS` and `BUILD.TAB.TRAPS` keys into `translations.csv` for full multi-language support.
- **Visual Polish**: 
  - Adjusted margins and separations to ensure the tabs align perfectly with the existing HUD aesthetic.
  - Disabled focus mode on tab buttons to prevent unwanted selection outlines.

## Test Plan
- [x] Open build menu: Verify it defaults to the "Tours" tab.
- [x] Switch to "Pièges" tab: Verify only traps are displayed and towers are hidden.
- [x] Switch back to "Tours": Verify only towers are displayed.
- [x] Language check: Verify tab labels update correctly when switching between English and French.
- [x] Resolution check: Ensure the new tab layout remains aligned on different screen ratios.