### PR TITLE
Color damage popups by tower and add unlock_armory

### DIFF
--- a/scenes/gameplay/entities/bullet/aoe_arrow.gd
+++ b/scenes/gameplay/entities/bullet/aoe_arrow.gd
@@ -88,7 +88,7 @@ func _handle_impact(enemy: IEnemy) -> void:
 	_is_exploding = true
 
 	# Apply direct hit damage
-	enemy.take_damage(damage, IEnemy.DamageType.DEFAULT)
+	enemy.take_damage(damage, IEnemy.DamageType.DEFAULT, self)
 
 	# Apply AOE damage to nearby enemies
 	_apply_aoe_damage(enemy)
@@ -108,7 +108,7 @@ func _apply_aoe_damage(direct_hit_enemy: IEnemy) -> void:
 		for nearby_enemy in aoe_enemies:
 			if nearby_enemy != direct_hit_enemy and is_instance_valid(nearby_enemy):
 				var aoe_damage: int = roundi(damage * AOE_DAMAGE_MULTIPLIER)
-				nearby_enemy.take_damage(aoe_damage, IEnemy.DamageType.DEFAULT)
+				nearby_enemy.take_damage(aoe_damage, IEnemy.DamageType.DEFAULT, self)
 
 
 ## Stop arrow movement and hide sprite (factorized)

--- a/scenes/gameplay/entities/enemy/i_enemy.gd
+++ b/scenes/gameplay/entities/enemy/i_enemy.gd
@@ -127,6 +127,7 @@ var _electrify_remaining: float = 0.0
 var _electrify_tick_damage: float = 0.0
 var _electrify_tick_interval: float = 0.0
 var _electrify_tick_remaining: float = 0.0
+var _electrify_source: Variant = null
 
 
 # Built-in functions
@@ -273,7 +274,7 @@ func is_electrified() -> bool:
 	return _electrified
 
 ## Applies an electrified debuff: temporary slow + periodic electric damage.
-func apply_electrify_effect(duration: float, slow_amount: float, tick_damage: float, tick_interval: float, _source: Variant = null) -> void:
+func apply_electrify_effect(duration: float, slow_amount: float, tick_damage: float, tick_interval: float, source: Variant = null) -> void:
 	if duration <= 0.0:
 		return
 
@@ -297,6 +298,7 @@ func apply_electrify_effect(duration: float, slow_amount: float, tick_damage: fl
 	_electrify_tick_damage = maxf(_electrify_tick_damage, tick_damage)
 	_electrify_tick_interval = normalized_interval
 	_electrify_tick_remaining = minf(_electrify_tick_remaining if _electrify_tick_remaining > 0.0 else normalized_interval, normalized_interval)
+	_electrify_source = source
 
 
 ## Applies a stun effect to the enemy.
@@ -341,7 +343,7 @@ func _process_electrify(delta: float) -> void:
 	_electrify_tick_remaining -= delta
 
 	if _electrify_tick_remaining <= 0.0 and _electrify_tick_damage > 0.0:
-		take_damage(_electrify_tick_damage, DamageType.DEFAULT)
+		take_damage(_electrify_tick_damage, DamageType.DEFAULT, _electrify_source)
 		_electrify_tick_remaining = _electrify_tick_interval
 
 	if _electrify_remaining <= 0.0:
@@ -359,6 +361,7 @@ func _clear_electrify_effect() -> void:
 	_electrify_tick_damage = 0.0
 	_electrify_tick_interval = 0.0
 	_electrify_tick_remaining = 0.0
+	_electrify_source = null
 	pop_slow_visual()
 
 func _apply_idle_modulate() -> void:

--- a/scenes/ui/popup/popup_spawner.gd
+++ b/scenes/ui/popup/popup_spawner.gd
@@ -8,6 +8,14 @@ extends Marker2D
 @export var damage_popup_node: PackedScene
 @export var popup_node: PackedScene
 
+# Constants
+const TOWER_COLORS: Dictionary = {
+	"bat_01": Color.WHITE, # Arbre à chat'rché (White)
+	"bat_02": Color("#744187"), # Tour Cataboom (Purple)
+	"bat_08": Color("#00ffff"), # Tour Tesla (Cyan)
+	"bat_09": Color("#ff8c00"), # Tour Inferno (Dark Orange)
+}
+
 # core
 func _ready() -> void:
 	assert(popup_node != null, "popup_node scene not assigned")
@@ -24,6 +32,8 @@ func display_damage(amount: float, color: Color = Color.WHITE, is_critical: bool
 	if damage_popup_node == null:
 		return
 	
+	var final_color: Color = color
+	
 	# Check if the damage source requires popup accumulation (e.g., continuous fire)
 	var should_accumulate: bool = false
 	if get_parent() is IEnemy:
@@ -35,8 +45,13 @@ func display_damage(amount: float, color: Color = Color.WHITE, is_critical: bool
 		elif source is IBullet and is_instance_valid(source.tower_owner):
 			tower = source.tower_owner
 			
-		if tower != null and tower.use_accumulative_popups:
-			should_accumulate = true
+		if tower != null:
+			if tower.use_accumulative_popups:
+				should_accumulate = true
+			
+			# Apply tower-specific color if defined
+			if TOWER_COLORS.has(tower.tower_id):
+				final_color = TOWER_COLORS[tower.tower_id]
 	
 	# Optimization: check if an active popup already exists for accumulation
 	if should_accumulate and _active_popups.has(self) and is_instance_valid(_active_popups[self]):
@@ -47,7 +62,7 @@ func display_damage(amount: float, color: Color = Color.WHITE, is_critical: bool
 
 	var damage_popup: DamagePopup = damage_popup_node.instantiate()
 	damage_popup.amount = amount
-	damage_popup.color = color
+	damage_popup.color = final_color
 	damage_popup.is_critical = is_critical
 	
 	if should_accumulate:

--- a/scripts/commands/unlock_armory.gd
+++ b/scripts/commands/unlock_armory.gd
@@ -1,0 +1,30 @@
+## © [2026] A7 Studio. All rights reserved. Trademark.
+##
+## Unlocks all armory nodes from the debug console.
+extends ICommand
+
+
+# Public functions
+func description() -> String:
+	return "Unlocks every armory node instantly."
+
+
+func get_args() -> Array[Dictionary]:
+	return []
+
+
+# Private functions
+func _execute(console: Console, _args: Array) -> int:
+	var node_ids: Array[String] = ArmoryManager.get_node_ids_ordered()
+	if node_ids.is_empty():
+		console.push_error_("No armory nodes found.")
+		return ERR_UNKNOWN_BEHAVIOR
+
+	var granted_count: int = 0
+	for node_id in node_ids:
+		var was_purchased: bool = ArmoryManager.is_node_purchased(node_id)
+		if ArmoryManager.debug_grant_node(node_id) and not was_purchased:
+			granted_count += 1
+
+	console.push_text("Armory unlocked: %d/%d nodes granted." % [granted_count, node_ids.size()])
+	return OK


### PR DESCRIPTION
## Summary
This PR improves combat readability by coloring damage popups based on the source tower (bat_01, bat_02, bat_08, bat_09), while preserving critical-hit coloring and Inferno accumulation behavior.  
It also adds a debug console command, `unlock_armory`, to instantly unlock all armory nodes.

## Key Changes
- **Tower-Specific Popup Colors**: Added a `tower_id -> Color` mapping in `scenes/ui/popup/popup_spawner.gd`.
- **Source Resolution**: Popup color selection now reliably resolves the source from `IEnemy.last_source` (direct tower or `IBullet.tower_owner`).
- **AOE Source Propagation Fix**: Updated `scenes/gameplay/entities/bullet/aoe_arrow.gd` so both direct-hit and AOE damage pass `self` to `take_damage(...)`, preventing fallback to default white.
- **Electrify Tick Consistency**: Updated `scenes/gameplay/entities/enemy/i_enemy.gd` to store/reuse electrify source so periodic tick damage keeps tower identity.
- **Debug Command**: Added `scripts/commands/unlock_armory.gd` to unlock every armory node from the in-game debug console.

## Test Plan
- [x] Verify `bat_01` popup damage is white.
- [x] Verify `bat_02` popup damage is purple (`#744187`), including AOE damage.
- [x] Verify `bat_08` popup damage uses its dedicated color (including electrify ticks).
- [x] Verify `bat_09` keeps accumulative popup behavior with its dedicated color.
- [x] Verify critical hits remain yellow.
- [x] Run `unlock_armory` from debug console and confirm all armory nodes are unlocked.