### PR TITLE
Align armory visuals with in-game construction menu

### DIFF
--- a/resources/armory/armory.json
+++ b/resources/armory/armory.json
@@ -119,6 +119,13 @@
 			"effects": []
 		},
 		{
+			"id": "unlock_bat_09_branch_b",
+			"cost_stars": 1,
+			"prerequisites": ["unlock_bat_09"],
+			"category": "periphery_upgrade",
+			"effects": []
+		},
+		{
 			"id": "unlock_bat_08",
 			"cost_stars": 1,
 			"prerequisites": ["unlock_bat_02"],
@@ -129,13 +136,6 @@
 			"id": "unlock_bat_08_branch_a",
 			"cost_stars": 1,
 			"prerequisites": ["unlock_bat_08"],
-			"category": "periphery_upgrade",
-			"effects": []
-		},
-		{
-			"id": "unlock_bat_09_branch_b",
-			"cost_stars": 1,
-			"prerequisites": ["unlock_bat_09"],
 			"category": "periphery_upgrade",
 			"effects": []
 		},

--- a/scenes/gameplay/entities/bullet/inferno_beam.tscn
+++ b/scenes/gameplay/entities/bullet/inferno_beam.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=3 uid="uid://c8y7x3n8u5r4e"]
 
-[ext_resource type="Script" path="res://scenes/gameplay/entities/bullet/inferno_beam.gd" id="1_script"]
+[ext_resource type="Script" uid="uid://cl1yhtpukhc3r" path="res://scenes/gameplay/entities/bullet/inferno_beam.gd" id="1_script"]
 
 [sub_resource type="Gradient" id="Gradient_sparks"]
 colors = PackedColorArray(1, 1, 1, 1, 1, 0.5, 0, 0)

--- a/scenes/ui/menus/armory/armory.gd
+++ b/scenes/ui/menus/armory/armory.gd
@@ -159,8 +159,11 @@ func _create_armory_item(node_id: String) -> ArmoryItem:
 		return null
 	var cost: int = int(node.get("cost_stars", 0))
 	item.node_id = node_id
+	item.node_name = _get_node_name(node_id)
 	item.cost_stars = cost
-	item.icon_texture = _resolve_icon_texture(node)
+	var icon_data: Dictionary = _resolve_icon_data(node)
+	item.icon_texture = icon_data.get("texture")
+	item.icon_modulate = icon_data.get("modulate", Color.WHITE)
 	if not item.buy_requested.is_connected(_on_buy_requested):
 		item.buy_requested.connect(_on_buy_requested)
 	if not item.selected.is_connected(_on_item_selected):
@@ -168,31 +171,51 @@ func _create_armory_item(node_id: String) -> ArmoryItem:
 	return item
 
 
-## Loads a tower/trap scene and returns the first useful preview ([Sprite2D] texture or first [AnimatedSprite2D] idle frame).
-func _extract_preview_texture(scene_path: String) -> Texture2D:
+## Loads a tower/trap scene and returns preview data: [code]texture[/code] and [code]modulate[/code].
+func _extract_preview_data(scene_path: String) -> Dictionary:
+	var out: Dictionary = {"texture": _FALLBACK_ICON, "modulate": Color.WHITE}
 	var packed_scene: PackedScene = StatsDB.load_packed_scene(scene_path)
 	if packed_scene == null:
-		return _FALLBACK_ICON
+		return out
 	var entity: Node = packed_scene.instantiate()
 	if entity == null:
-		return _FALLBACK_ICON
-	var sprite: Sprite2D = entity.find_child("Sprite2D", true, false) as Sprite2D
-	if sprite != null and sprite.texture != null:
-		entity.queue_free()
-		return sprite.texture
-	var animated: AnimatedSprite2D = entity.find_child("AnimatedSprite2D", true, false) as AnimatedSprite2D
-	if animated != null and animated.sprite_frames != null:
-		var animation_name: StringName = &"idle"
-		if not animated.sprite_frames.has_animation(animation_name):
-			var names: PackedStringArray = animated.sprite_frames.get_animation_names()
-			if not names.is_empty():
-				animation_name = StringName(names[0])
-		if animated.sprite_frames.has_animation(animation_name) and animated.sprite_frames.get_frame_count(animation_name) > 0:
-			var texture: Texture2D = animated.sprite_frames.get_frame_texture(animation_name, 0)
-			entity.queue_free()
-			return texture if texture != null else _FALLBACK_ICON
+		return out
+	
+	# Match build_card.gd logic: look for "Sprite" or "Sprite2D"
+	var sprite_node: Node = entity.get_node_or_null("Sprite")
+	if sprite_node == null:
+		sprite_node = entity.get_node_or_null("Sprite2D")
+	
+	# Better way to find by type in Godot 4
+	if sprite_node == null:
+		var sprites = entity.find_children("*", "Sprite2D", true, false)
+		if not sprites.is_empty():
+			sprite_node = sprites[0]
+	if sprite_node == null:
+		var anim_sprites = entity.find_children("*", "AnimatedSprite2D", true, false)
+		if not anim_sprites.is_empty():
+			sprite_node = anim_sprites[0]
+	
+	if sprite_node is Sprite2D:
+		var s: Sprite2D = sprite_node as Sprite2D
+		out["texture"] = s.texture
+		# Traps use modulate; favour self_modulate when non-white
+		out["modulate"] = s.self_modulate if s.self_modulate != Color.WHITE else s.modulate
+	elif sprite_node is AnimatedSprite2D:
+		var anim_sprite: AnimatedSprite2D = sprite_node as AnimatedSprite2D
+		# Towers use self_modulate on AnimatedSprite2D
+		out["modulate"] = anim_sprite.self_modulate if anim_sprite.self_modulate != Color.WHITE else anim_sprite.modulate
+		if anim_sprite.sprite_frames:
+			var animation_name: StringName = &"idle"
+			if not anim_sprite.sprite_frames.has_animation(animation_name):
+				var names: PackedStringArray = anim_sprite.sprite_frames.get_animation_names()
+				if not names.is_empty():
+					animation_name = StringName(names[0])
+			if anim_sprite.sprite_frames.has_animation(animation_name) and anim_sprite.sprite_frames.get_frame_count(animation_name) > 0:
+				out["texture"] = anim_sprite.sprite_frames.get_frame_texture(animation_name, 0)
+	
 	entity.queue_free()
-	return _FALLBACK_ICON
+	return out
 
 
 ## Translation for [code]ARMORY.NODE.{ID}.DESC[/code], or empty if the key is missing.
@@ -293,7 +316,9 @@ func _refresh() -> void:
 
 
 ## Picks a card icon from the first [code]unlock_tower[/code] or [code]unlock_trap[/code] effect by previewing the linked scene.
-func _resolve_icon_texture(node: Dictionary) -> Texture2D:
+## [br]Fallback: tries to find a tower or trap ID within the node ID string.
+func _resolve_icon_data(node: Dictionary) -> Dictionary:
+	var fallback: Dictionary = {"texture": _FALLBACK_ICON, "modulate": Color.WHITE}
 	for effect in node.get("effects", []):
 		if typeof(effect) != TYPE_DICTIONARY:
 			continue
@@ -302,13 +327,25 @@ func _resolve_icon_texture(node: Dictionary) -> Texture2D:
 			var tower_id: String = str(effect.get("tower_id", ""))
 			if StatsDB.has_tower(tower_id):
 				var tower: Dictionary = StatsDB.get_tower(tower_id)
-				return _extract_preview_texture(str(tower.get("scene", "")))
+				return _extract_preview_data(str(tower.get("scene", "")))
 		elif effect_type == "unlock_trap":
 			var trap_id: String = str(effect.get("trap_id", ""))
 			if StatsDB.has_trap(trap_id):
 				var trap: Dictionary = StatsDB.get_trap(trap_id)
-				return _extract_preview_texture(str(trap.get("scene", "")))
-	return _FALLBACK_ICON
+				return _extract_preview_data(str(trap.get("scene", "")))
+	
+	# Fallback: try to find a tower/trap ID in the node ID (e.g. "unlock_bat_01_branch_a" -> "bat_01")
+	var node_id: String = node.get("id", "")
+	for tid in StatsDB.get_tower_ids():
+		if tid in node_id:
+			var tower: Dictionary = StatsDB.get_tower(tid)
+			return _extract_preview_data(str(tower.get("scene", "")))
+	for trap_id in StatsDB.get_trap_ids():
+		if trap_id in node_id:
+			var trap: Dictionary = StatsDB.get_trap(trap_id)
+			return _extract_preview_data(str(trap.get("scene", "")))
+			
+	return fallback
 
 
 ## Highlights one card, shows title and either prerequisite hint or full description depending on purchase/prereq state.

--- a/scenes/ui/menus/armory/armory.gd
+++ b/scenes/ui/menus/armory/armory.gd
@@ -159,7 +159,6 @@ func _create_armory_item(node_id: String) -> ArmoryItem:
 		return null
 	var cost: int = int(node.get("cost_stars", 0))
 	item.node_id = node_id
-	item.node_name = _get_node_name(node_id)
 	item.cost_stars = cost
 	var icon_data: Dictionary = _resolve_icon_data(node)
 	item.icon_texture = icon_data.get("texture")

--- a/scenes/ui/menus/armory/armory.tscn
+++ b/scenes/ui/menus/armory/armory.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://6soot5tpvyhx" path="res://scenes/ui/menus/armory/armory.gd" id="1_arm"]
 [ext_resource type="Texture2D" uid="uid://0lgpu16nkbho" path="res://assets/ui/icons/Button Close.svg" id="2_close"]
 [ext_resource type="Theme" uid="uid://dr31fy67cgji3" path="res://assets/resources/themes/generic.tres" id="3_theme"]
-[ext_resource type="Texture2D" uid="uid://8y5uhgfsgmp8" path="res://assets/ui/icons/Star.png" id="3_uh7sf"]
+[ext_resource type="Texture2D" uid="uid://8y5uhgfsgmp8" path="res://assets/ui/icons/Star.png" id="3_star"]
 [ext_resource type="Texture2D" uid="uid://cvut87og2mth" path="res://assets/ui/buttons/Bouton orange.svg" id="5_orange_button"]
 [ext_resource type="Texture2D" uid="uid://c8b8irfugbxdj" path="res://assets/environment/backgrounds/Fond Menu 02.svg" id="6_x4aod"]
 [ext_resource type="Texture2D" uid="uid://c5jwmpccl40pb" path="res://assets/environment/backgrounds/Fond Menu 01.svg" id="7_fond01"]
@@ -75,7 +75,7 @@ alignment = 1
 [node name="StarsIconTextureRect" type="TextureRect" parent="MainMargin/VBox/HeaderHBox/StarsStrip"]
 custom_minimum_size = Vector2(32, 32)
 layout_mode = 2
-texture = ExtResource("3_uh7sf")
+texture = ExtResource("3_star")
 expand_mode = 1
 stretch_mode = 5
 

--- a/scenes/ui/menus/armory/armory_item.gd
+++ b/scenes/ui/menus/armory/armory_item.gd
@@ -35,7 +35,6 @@ const FRAME_GREY: Texture2D = preload("res://assets/ui/building_cards/Grey Frame
 @export var is_prerequisites_met: bool = true
 @export var is_purchased: bool = false
 @export var node_id: String = ""
-@export var node_name: String = ""
 
 var _is_card_selected: bool = false
 
@@ -46,7 +45,6 @@ var _is_card_selected: bool = false
 @onready var preview_texture_rect: TextureRect = %PreviewTextureRect
 @onready var price_label: Label = %PriceLabel
 @onready var stars_icon_texture_rect: TextureRect = %StarsIconTextureRect
-@onready var title_label: Label = %TitleLabel
 
 @onready var signals: Array[Dictionary] = [
 	{SignalUtil.WHO: buy_button, SignalUtil.WHAT: "pressed", SignalUtil.TO: _on_buy_button_pressed},
@@ -63,7 +61,6 @@ func _ready() -> void:
 	assert(preview_texture_rect != null, "preview_texture_rect node not found")
 	assert(price_label != null, "price_label node not found")
 	assert(stars_icon_texture_rect != null, "stars_icon_texture_rect node not found")
-	assert(title_label != null, "title_label node not found")
 	SignalUtil.connects(signals)
 	# Keep button layout space at all times to avoid vertical jumps on selection.
 	buy_button.visible = true
@@ -99,7 +96,6 @@ func _on_card_texture_button_pressed() -> void:
 
 ## Applies textures, labels, price visibility, disabled/mouse_filter rules, and buy-row alpha from current flags.
 func _update_visuals() -> void:
-	title_label.text = node_name
 	preview_texture_rect.texture = icon_texture
 	preview_texture_rect.modulate = icon_modulate
 	price_label.text = "%d" % cost_stars

--- a/scenes/ui/menus/armory/armory_item.gd
+++ b/scenes/ui/menus/armory/armory_item.gd
@@ -17,6 +17,10 @@ const COLOR_BUY_BLOCKED_MODULATE: Color = Color(0.55, 0.55, 0.55, 1.0)
 const COLOR_BUY_LABEL_DEFAULT: Color = Color(0.137255, 0.215686, 0.223529, 1.0)
 const COLOR_PRICE_AFFORDABLE: Color = Color(1.0, 1.0, 1.0, 1.0)
 const COLOR_PRICE_UNAFFORDABLE: Color = Color(0.92, 0.26, 0.22, 1.0)
+const CARD_DIM_UNAFFORDABLE: float = 0.82
+const CARD_MODULATE_AFFORDABLE: Color = Color.WHITE
+const CARD_MODULATE_UNAFFORDABLE: Color = Color(CARD_DIM_UNAFFORDABLE, CARD_DIM_UNAFFORDABLE, CARD_DIM_UNAFFORDABLE, 1.0)
+const PRICE_LABEL_MODULATE_VS_DIM: Color = Color(1.0 / CARD_DIM_UNAFFORDABLE, 1.0 / CARD_DIM_UNAFFORDABLE, 1.0 / CARD_DIM_UNAFFORDABLE, 1.0)
 const BUY_BUTTON_BLUE: Texture2D = preload("res://assets/ui/buttons/Bouton Bleu.svg")
 const BUY_BUTTON_GREEN: Texture2D = preload("res://assets/ui/buttons/Bouton Vert.svg")
 const FRAME_BLUE: Texture2D = preload("res://assets/ui/building_cards/Blue Frame.svg")
@@ -25,11 +29,13 @@ const FRAME_GREY: Texture2D = preload("res://assets/ui/building_cards/Grey Frame
 
 @export var cost_stars: int = 0
 @export var icon_texture: Texture2D = null
+@export var icon_modulate: Color = Color.WHITE
 @export var is_affordable: bool = false
 @export var is_legacy_mode: bool = false
 @export var is_prerequisites_met: bool = true
 @export var is_purchased: bool = false
 @export var node_id: String = ""
+@export var node_name: String = ""
 
 var _is_card_selected: bool = false
 
@@ -40,6 +46,7 @@ var _is_card_selected: bool = false
 @onready var preview_texture_rect: TextureRect = %PreviewTextureRect
 @onready var price_label: Label = %PriceLabel
 @onready var stars_icon_texture_rect: TextureRect = %StarsIconTextureRect
+@onready var title_label: Label = %TitleLabel
 
 @onready var signals: Array[Dictionary] = [
 	{SignalUtil.WHO: buy_button, SignalUtil.WHAT: "pressed", SignalUtil.TO: _on_buy_button_pressed},
@@ -56,6 +63,7 @@ func _ready() -> void:
 	assert(preview_texture_rect != null, "preview_texture_rect node not found")
 	assert(price_label != null, "price_label node not found")
 	assert(stars_icon_texture_rect != null, "stars_icon_texture_rect node not found")
+	assert(title_label != null, "title_label node not found")
 	SignalUtil.connects(signals)
 	# Keep button layout space at all times to avoid vertical jumps on selection.
 	buy_button.visible = true
@@ -91,9 +99,24 @@ func _on_card_texture_button_pressed() -> void:
 
 ## Applies textures, labels, price visibility, disabled/mouse_filter rules, and buy-row alpha from current flags.
 func _update_visuals() -> void:
+	title_label.text = node_name
 	preview_texture_rect.texture = icon_texture
+	preview_texture_rect.modulate = icon_modulate
 	price_label.text = "%d" % cost_stars
-	price_label.add_theme_color_override("font_color", COLOR_PRICE_AFFORDABLE if is_affordable else COLOR_PRICE_UNAFFORDABLE)
+	
+	var can_buy: bool = not is_purchased and not is_legacy_mode and is_prerequisites_met and is_affordable
+	var only_blocked_by_stars: bool = is_prerequisites_met and not is_affordable and not is_purchased and not is_legacy_mode
+	
+	# Match build_card.gd color correction
+	modulate = CARD_MODULATE_AFFORDABLE if (can_buy or is_purchased or is_legacy_mode) else CARD_MODULATE_UNAFFORDABLE
+	
+	if not is_affordable and not is_purchased and not is_legacy_mode:
+		price_label.modulate = PRICE_LABEL_MODULATE_VS_DIM
+		price_label.add_theme_color_override("font_color", COLOR_PRICE_UNAFFORDABLE)
+	else:
+		price_label.modulate = Color.WHITE
+		price_label.add_theme_color_override("font_color", COLOR_PRICE_AFFORDABLE)
+
 	var buy_rgb: Color = Color.WHITE
 	if is_purchased:
 		buy_button.texture_normal = BUY_BUTTON_GREEN
@@ -126,14 +149,14 @@ func _update_visuals() -> void:
 		buy_label.text = tr("ARMORY.BUY")
 		price_label.visible = true
 		stars_icon_texture_rect.visible = true
-	var only_blocked_by_stars: bool = is_prerequisites_met and not is_affordable and not is_purchased and not is_legacy_mode
 	if only_blocked_by_stars:
 		buy_label.add_theme_color_override("font_color", COLOR_PRICE_UNAFFORDABLE)
 	else:
 		buy_label.add_theme_color_override("font_color", COLOR_BUY_LABEL_DEFAULT)
-	var can_buy: bool = not is_purchased and not is_legacy_mode and is_prerequisites_met and is_affordable
+	
 	buy_button.disabled = not can_buy and not only_blocked_by_stars
 	var allow_buy_click: bool = _is_card_selected and can_buy
 	buy_button.mouse_filter = Control.MOUSE_FILTER_STOP if allow_buy_click else Control.MOUSE_FILTER_IGNORE
+	
 	var alpha: float = 1.0 if _is_card_selected else 0.0
 	buy_button.modulate = Color(buy_rgb.r, buy_rgb.g, buy_rgb.b, alpha)

--- a/scenes/ui/menus/armory/armory_item.tscn
+++ b/scenes/ui/menus/armory/armory_item.tscn
@@ -3,19 +3,48 @@
 [ext_resource type="Script" uid="uid://yn0xr1v34u6y" path="res://scenes/ui/menus/armory/armory_item.gd" id="1_armory_item_script"]
 [ext_resource type="Theme" uid="uid://dr31fy67cgji3" path="res://assets/resources/themes/generic.tres" id="2_theme"]
 [ext_resource type="Texture2D" uid="uid://cdesir3miwmug" path="res://assets/ui/building_cards/Green Frame.svg" id="3_green_frame"]
-[ext_resource type="Texture2D" uid="uid://yayv0hygrr3u" path="res://assets/ui/building_cards/Blue Backgrond.svg" id="4_blue_background"]
-[ext_resource type="Texture2D" uid="uid://deifsvtkdkqo1" path="res://assets/ui/buttons/Bouton Bleu.svg" id="5_blue_button"]
-[ext_resource type="Texture2D" uid="uid://8y5uhgfsgmp8" path="res://assets/ui/icons/Star.png" id="6_krslc"]
+[ext_resource type="Texture2D" uid="uid://85310xv6g30a" path="res://assets/ui/building_cards/Construction Tower Title.svg" id="4_title_bg"]
+[ext_resource type="Texture2D" uid="uid://yayv0hygrr3u" path="res://assets/ui/building_cards/Blue Backgrond.svg" id="5_blue_background"]
+[ext_resource type="Texture2D" uid="uid://deifsvtkdkqo1" path="res://assets/ui/buttons/Bouton Bleu.svg" id="6_blue_button"]
+[ext_resource type="Texture2D" uid="uid://8y5uhgfsgmp8" path="res://assets/ui/icons/Star.png" id="7_star"]
 
 [node name="ArmoryItem" type="VBoxContainer"]
 custom_minimum_size = Vector2(180, 260)
-theme_override_constants/separation = 8
+theme_override_constants/separation = 4
 alignment = 1
 script = ExtResource("1_armory_item_script")
+
+[node name="TitleAspectRatioContainer" type="AspectRatioContainer" parent="."]
+layout_mode = 2
+size_flags_vertical = 3
+size_flags_stretch_ratio = 0.25
+ratio = 3.0
+
+[node name="TitleTextureRect" type="TextureRect" parent="TitleAspectRatioContainer"]
+layout_mode = 2
+texture = ExtResource("4_title_bg")
+expand_mode = 1
+stretch_mode = 5
+
+[node name="TitleLabel" type="Label" parent="TitleAspectRatioContainer/TitleTextureRect"]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("2_theme")
+theme_override_font_sizes/font_size = 14
+text = "NODE NAME"
+horizontal_alignment = 1
+vertical_alignment = 1
+uppercase = true
 
 [node name="CardAspectRatioContainer" type="AspectRatioContainer" parent="."]
 custom_minimum_size = Vector2(160, 160)
 layout_mode = 2
+size_flags_vertical = 3
 
 [node name="CardTextureButton" type="TextureButton" parent="CardAspectRatioContainer"]
 unique_name_in_owner = true
@@ -49,7 +78,7 @@ offset_right = 0.51001
 offset_bottom = -0.48999
 grow_horizontal = 2
 grow_vertical = 2
-texture = ExtResource("4_blue_background")
+texture = ExtResource("5_blue_background")
 expand_mode = 1
 stretch_mode = 4
 
@@ -74,7 +103,7 @@ unique_name_in_owner = true
 visible = false
 custom_minimum_size = Vector2(170, 52)
 layout_mode = 2
-texture_normal = ExtResource("5_blue_button")
+texture_normal = ExtResource("6_blue_button")
 ignore_texture_size = true
 stretch_mode = 5
 
@@ -110,7 +139,7 @@ uppercase = true
 unique_name_in_owner = true
 custom_minimum_size = Vector2(20, 20)
 layout_mode = 2
-texture = ExtResource("6_krslc")
+texture = ExtResource("7_star")
 expand_mode = 1
 stretch_mode = 5
 

--- a/scenes/ui/menus/armory/armory_item.tscn
+++ b/scenes/ui/menus/armory/armory_item.tscn
@@ -1,45 +1,17 @@
-[gd_scene load_steps=7 format=3 uid="uid://6mhjyovq8wdc"]
+[gd_scene load_steps=6 format=3 uid="uid://6mhjyovq8wdc"]
 
 [ext_resource type="Script" uid="uid://yn0xr1v34u6y" path="res://scenes/ui/menus/armory/armory_item.gd" id="1_armory_item_script"]
 [ext_resource type="Theme" uid="uid://dr31fy67cgji3" path="res://assets/resources/themes/generic.tres" id="2_theme"]
 [ext_resource type="Texture2D" uid="uid://cdesir3miwmug" path="res://assets/ui/building_cards/Green Frame.svg" id="3_green_frame"]
-[ext_resource type="Texture2D" uid="uid://85310xv6g30a" path="res://assets/ui/building_cards/Construction Tower Title.svg" id="4_title_bg"]
 [ext_resource type="Texture2D" uid="uid://yayv0hygrr3u" path="res://assets/ui/building_cards/Blue Backgrond.svg" id="5_blue_background"]
 [ext_resource type="Texture2D" uid="uid://deifsvtkdkqo1" path="res://assets/ui/buttons/Bouton Bleu.svg" id="6_blue_button"]
 [ext_resource type="Texture2D" uid="uid://8y5uhgfsgmp8" path="res://assets/ui/icons/Star.png" id="7_star"]
 
 [node name="ArmoryItem" type="VBoxContainer"]
-custom_minimum_size = Vector2(180, 260)
+custom_minimum_size = Vector2(180, 200)
 theme_override_constants/separation = 4
 alignment = 1
 script = ExtResource("1_armory_item_script")
-
-[node name="TitleAspectRatioContainer" type="AspectRatioContainer" parent="."]
-layout_mode = 2
-size_flags_vertical = 3
-size_flags_stretch_ratio = 0.25
-ratio = 3.0
-
-[node name="TitleTextureRect" type="TextureRect" parent="TitleAspectRatioContainer"]
-layout_mode = 2
-texture = ExtResource("4_title_bg")
-expand_mode = 1
-stretch_mode = 5
-
-[node name="TitleLabel" type="Label" parent="TitleAspectRatioContainer/TitleTextureRect"]
-unique_name_in_owner = true
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-theme = ExtResource("2_theme")
-theme_override_font_sizes/font_size = 14
-text = "NODE NAME"
-horizontal_alignment = 1
-vertical_alignment = 1
-uppercase = true
 
 [node name="CardAspectRatioContainer" type="AspectRatioContainer" parent="."]
 custom_minimum_size = Vector2(160, 160)

--- a/scenes/ui/menus/building_selection/building_cards/build_card_bat_08.tscn
+++ b/scenes/ui/menus/building_selection/building_cards/build_card_bat_08.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=10 format=3 uid="uid://g880dtp4ta31"]
 
 [ext_resource type="Script" uid="uid://e0qqc3xugp8k" path="res://scenes/ui/menus/building_selection/building_cards/build_card.gd" id="1_script"]
-[ext_resource type="PackedScene" path="res://scenes/gameplay/entities/tower/towers/bat_08.tscn" id="2_entity"]
+[ext_resource type="PackedScene" uid="uid://vsaqk62gl8qk" path="res://scenes/gameplay/entities/tower/towers/bat_08.tscn" id="2_entity"]
 [ext_resource type="Texture2D" uid="uid://85310xv6g30a" path="res://assets/ui/building_cards/Construction Tower Title.svg" id="3_title"]
 [ext_resource type="Theme" uid="uid://dr31fy67cgji3" path="res://assets/resources/themes/generic.tres" id="4_theme"]
 [ext_resource type="Texture2D" uid="uid://cdesir3miwmug" path="res://assets/ui/building_cards/Green Frame.svg" id="5_frame"]


### PR DESCRIPTION
## Summary
Updated the armory to use the same sprites, colors, and visual feedback as the in-game construction menu. This ensures players can easily identify buildings and traps being unlocked or upgraded, providing a more consistent and intuitive experience across the UI.



## Key Changes
- **Accurate Previews**: Improved the icon resolution logic in `armory.gd` to fetch actual building and trap sprites (including support for `AnimatedSprite2D` like the Cat Tree) instead of using generic star icons for upgrades.
- **Modulation Support**: Added support for both `modulate` and `self_modulate` in the preview extraction. This ensures tinted entities like the **Poison Trap** (purple), **Stun Trap** (yellow), **Tesla Tower** (yellow), and **Inferno Tower** (red) appear correctly.
- **Visual Feedback**: Implemented the same color correction logic as the in-game build cards. Unaffordable items are now dimmed (`0.82` modulate) while their price labels use counter-modulation to remain bright and readable.
- **UI Cleanup**: Removed the redundant green title boxes above armory items to match the streamlined aesthetic of the construction menu and reduce vertical clutter.
- **Currency Consistency**: Ensured the armory continues to use stars as the primary resource, reverting an accidental switch to coins while maintaining the improved layout.



## Test Plan
- [x] **Entity Previews**: Verified that all armory nodes show the correct building/trap sprite.
- [x] **Color Accuracy**: Confirmed that tinted traps and towers maintain their specific colors in the armory cards.
- [x] **Affordability States**: Checked that locked/unaffordable items are correctly dimmed and that the price text remains legible.
- [x] **Layout**: Confirmed the removal of the title boxes and the adjusted card height.