### PR TITLE
fix(bullet): Prevent chaining to enemies on different paths

### DIFF
--- a/scenes/gameplay/entities/bullet/instant_lightning.gd
+++ b/scenes/gameplay/entities/bullet/instant_lightning.gd
@@ -124,6 +124,9 @@ func _find_next_chain_target(source_enemy: IEnemy, excluded_enemies: Array[IEnem
 		if not is_instance_valid(candidate_enemy) or excluded_enemies.has(candidate_enemy):
 			continue
 
+		if candidate_enemy.path != source_enemy.path:
+			continue
+
 		var distance: float = source_position.distance_to(candidate_enemy.global_position)
 		if distance > chain_range:
 			continue


### PR DESCRIPTION
## Summary
The Tesla tower's chain lightning was incorrectly jumping between enemies located on different map paths. This fix ensures the chain can only propagate to enemies that share the same path as the source enemy, preventing unintended cross-path chaining.

## Key Changes
- **Bug Fix**: Added a path check in `_find_next_chain_target` inside `instant_lightning.gd` — candidates whose `path` differs from the source enemy's `path` are now skipped before distance evaluation.

## Test Plan
- [x] Chain lightning only jumps to enemies on the same path as the initial target.
- [x] Chain still works correctly when multiple enemies are clustered on the same path.
- [x] No regressions on other bullet types or chain behavior.