### PR TITLE
balancing: First balancing pass on enemies, towers and upgrades

### DIFF
--- a/assets/resources/configs/stats.json
+++ b/assets/resources/configs/stats.json
@@ -1,37 +1,37 @@
 {
 	"enemies": {
 		"default_zombie": {
-			"max_health": 20,
-			"reward": 10,
+			"max_health": 100,
+			"reward": 20,
 			"scene": "res://scenes/gameplay/entities/enemy/enemies/ene.01.tscn",
 			"speed": 45
 		},
 		"damage_zombie": {
-			"max_health": 100,
-			"reward": 10,
+			"max_health": 200,
+			"reward": 40,
 			"scene": "res://scenes/gameplay/entities/enemy/enemies/ene.02.tscn",
-			"speed": 30
+			"speed": 25
 		},
 		"rat": {
-			"max_health": 10,
-			"reward": 10,
+			"max_health": 25,
+			"reward": 2,
 			"scene": "res://scenes/gameplay/entities/enemy/enemies/ene.03.tscn",
-			"speed": 100
+			"speed": 75
 		},
 		"splitter_zombie": {
 			"extra": {
 				"spawn_count": 4
 			},
-			"max_health": 80,
-			"reward": 20,
+			"max_health": 150,
+			"reward": 5,
 			"scene": "res://scenes/gameplay/entities/enemy/enemies/splitter_zombie.tscn",
 			"speed": 35
 		},
 		"small_zombie": {
-			"max_health": 10,
-			"reward": 5,
+			"max_health": 25,
+			"reward": 10,
 			"scene": "res://scenes/gameplay/entities/enemy/enemies/small_zombie.tscn",
-			"speed": 70
+			"speed": 75
 		},
     "minesweeper": {
 			"max_health": 70,
@@ -50,9 +50,9 @@
 				"tower_disable_duration": 3
 			},
 			"max_health": 1000,
-			"reward": 10,
+			"reward": 500,
 			"scene": "res://scenes/gameplay/entities/enemy/enemies/big_daddy.tscn",
-			"speed": 20
+			"speed": 35
 		}
 	},
 	"towers": {
@@ -64,16 +64,16 @@
 					"aoe_tick": 0,
 					"burn_damage_base": 0,
 					"burn_duration": 0,
-					"damage": 100,
+					"damage": 25,
 					"damage_multiplier": 0,
 					"pierce_count": 0,
 					"pierce_reduction": 0,
 					"speed": 500
 				},
 				"cost": 50,
-				"fire_rate": 1.5,
+				"fire_rate": 1.0,
 				"projectile_count": 1,
-				"shoot_range": 100,
+				"shoot_range": 55,
 				"spread_angle": 15
 			},
 			"level": 1,
@@ -87,7 +87,7 @@
 			"base": {
 				"bullet_stats": {
 					"aoe_duration": 0,
-					"aoe_range": 100,
+					"aoe_range": 15,
 					"aoe_tick": 0,
 					"burn_damage_base": 0,
 					"burn_duration": 0,
@@ -97,10 +97,10 @@
 					"pierce_reduction": 0,
 					"speed": 350
 				},
-				"cost": 50,
-				"fire_rate": 1.5,
+				"cost": 100,
+				"fire_rate": 0.5,
 				"projectile_count": 1,
-				"shoot_range": 150,
+				"shoot_range": 35,
 				"spread_angle": 15
 			},
 			"level": 1,
@@ -121,7 +121,7 @@
 					"chain_bounces": 0,
 					"chain_damage_falloff": 0,
 					"chain_range": 0,
-					"damage": 18,
+					"damage": 1.5,
 					"damage_multiplier": 0,
 					"electrify_duration": 0,
 					"electrify_slow_amount": 0,
@@ -133,10 +133,10 @@
 					"pierce_reduction": 0,
 					"speed": 0
 				},
-				"cost": 25,
-				"fire_rate": 2,
+				"cost": 150,
+				"fire_rate": 5,
 				"projectile_count": 1,
-				"shoot_range": 120,
+				"shoot_range": 55,
 				"spread_angle": 0
 			},
 			"level": 1,
@@ -152,7 +152,7 @@
 					"damage": 0.5,
 					"is_charging": false
 				},
-				"cost": 10,
+				"cost": 200,
 				"fire_rate": 10.0,
 				"projectile_count": 1,
 				"shoot_range": 100,
@@ -224,7 +224,7 @@
 	"upgrades": {
 		"bat_09_02": {
 			"bullet_stats": {
-				"damage": 0.1
+				"damage": 0.2
 			},
 			"changes": {
 				"bullet_stat": true,
@@ -240,7 +240,7 @@
 		},
 		"bat_09_03": {
 			"bullet_stats": {
-				"damage": 0.1
+				"damage": 0.3
 			},
 			"changes": {
 				"bullet_stat": true,
@@ -296,7 +296,7 @@
 				"aoe_range": 0,
 				"burn_damage_base": 0,
 				"burn_duration": 0,
-				"damage": 2,
+				"damage": 10,
 				"damage_multiplier": 0,
 				"pierce_count": 0,
 				"pierce_reduction": 0,
@@ -326,7 +326,7 @@
 				"aoe_range": 0,
 				"burn_damage_base": 0,
 				"burn_duration": 0,
-				"damage": 2,
+				"damage": 13,
 				"damage_multiplier": 0,
 				"pierce_count": 0,
 				"pierce_reduction": 0,
@@ -342,7 +342,7 @@
 				"bat_01_a_04",
 				"bat_01_b_04"
 			],
-			"price": 0,
+			"price": 100,
 			"tower_stats": {
 				"fire_rate": 0,
 				"level": 1,
@@ -358,9 +358,10 @@
 				"aoe_range": 0,
 				"burn_damage_base": 0,
 				"burn_duration": 0,
-				"damage": 100,
+				"damage": 27,
 				"damage_multiplier": 0,
-				"pierce_count": 10,
+				"dot_damage": 0,
+				"pierce_count": 1,
 				"pierce_reduction": 10,
 				"speed": -200
 			},
@@ -373,7 +374,7 @@
 			"next": [
 				"bat_01_a_05"
 			],
-			"price": 0,
+			"price": 125,
 			"tower_stats": {
 				"fire_rate": 0,
 				"level": 1,
@@ -388,9 +389,10 @@
 				"aoe_range": 0,
 				"burn_damage_base": 0,
 				"burn_duration": 0,
-				"damage": 5,
+				"damage": 25,
 				"damage_multiplier": 0,
-				"pierce_count": 1,
+				"dot_damage": 0,
+				"pierce_count": 2,
 				"pierce_reduction": 0,
 				"speed": 0
 			},
@@ -416,7 +418,7 @@
 				"aoe_range": 0,
 				"burn_damage_base": 0,
 				"burn_duration": 0,
-				"damage": -2,
+				"damage": -5,
 				"damage_multiplier": 0,
 				"pierce_count": 0,
 				"pierce_reduction": 0,
@@ -431,9 +433,9 @@
 			"next": [
 				"bat_01_b_05"
 			],
-			"price": 0,
+			"price": 125,
 			"tower_stats": {
-				"fire_rate": 1,
+				"fire_rate": 0.5,
 				"level": 1,
 				"projectile_count": 1,
 				"shoot_range": 0,
@@ -459,7 +461,7 @@
 				"tower_stat": true
 			},
 			"next": [],
-			"price": 0,
+			"price": 175,
 			"tower_stats": {
 				"fire_rate": 0,
 				"level": 1,
@@ -474,7 +476,7 @@
 				"aoe_range": 0,
 				"burn_damage_base": 0,
 				"burn_duration": 0,
-				"damage": 0,
+				"damage": 10,
 				"damage_multiplier": 0,
 				"pierce_count": 0,
 				"pierce_reduction": 0,
@@ -489,7 +491,7 @@
 			"next": [
 				"bat_02_03"
 			],
-			"price": 0,
+			"price": 100,
 			"tower_stats": {
 				"fire_rate": 0,
 				"level": 1,
@@ -504,7 +506,7 @@
 				"aoe_range": 0,
 				"burn_damage_base": 0,
 				"burn_duration": 0,
-				"damage": 0,
+				"damage": 15,
 				"damage_multiplier": 0,
 				"pierce_count": 0,
 				"pierce_reduction": 0,
@@ -520,7 +522,7 @@
 				"bat_02_a_04",
 				"bat_02_b_04"
 			],
-			"price": 0,
+			"price": 125,
 			"tower_stats": {
 				"fire_rate": 0,
 				"level": 1,
@@ -533,10 +535,10 @@
 			"bullet_scene_path": "res://scenes/gameplay/entities/bullet/fire_arrow.tscn",
 			"bullet_stats": {
 				"aoe_duration": 0,
-				"aoe_range": -20,
+				"aoe_range": -5,
 				"burn_damage_base": 10,
 				"burn_duration": 3,
-				"damage": 0,
+				"damage": 15,
 				"damage_multiplier": 0,
 				"pierce_count": 0,
 				"pierce_reduction": 0,
@@ -551,9 +553,9 @@
 			"next": [
 				"bat_02_a_05"
 			],
-			"price": 0,
+			"price": 175,
 			"tower_stats": {
-				"fire_rate": 0,
+				"fire_rate": 0.3,
 				"level": 1,
 				"projectile_count": 0,
 				"shoot_range": 0,
@@ -564,9 +566,9 @@
 			"bullet_stats": {
 				"aoe_duration": 0,
 				"aoe_range": 0,
-				"burn_damage_base": 0,
+				"burn_damage_base": 5,
 				"burn_duration": 0,
-				"damage": 0,
+				"damage": 20,
 				"damage_multiplier": 0,
 				"pierce_count": 0,
 				"pierce_reduction": 0,
@@ -579,7 +581,7 @@
 				"tower_stat": true
 			},
 			"next": [],
-			"price": 0,
+			"price": 175,
 			"tower_stats": {
 				"fire_rate": 0,
 				"level": 1,
@@ -591,10 +593,10 @@
 		"bat_02_b_04": {
 			"bullet_stats": {
 				"aoe_duration": 0,
-				"aoe_range": 20,
+				"aoe_range": 15,
 				"burn_damage_base": 0,
 				"burn_duration": 0,
-				"damage": 0,
+				"damage": 25,
 				"damage_multiplier": 0,
 				"pierce_count": 0,
 				"pierce_reduction": 0,
@@ -609,7 +611,7 @@
 			"next": [
 				"bat_02_b_05"
 			],
-			"price": 0,
+			"price": 175,
 			"tower_stats": {
 				"fire_rate": 0,
 				"level": 1,
@@ -621,10 +623,10 @@
 		"bat_02_b_05": {
 			"bullet_stats": {
 				"aoe_duration": 0,
-				"aoe_range": 20,
+				"aoe_range": 15,
 				"burn_damage_base": 0,
 				"burn_duration": 0,
-				"damage": 0,
+				"damage": 20,
 				"damage_multiplier": 0,
 				"pierce_count": 0,
 				"pierce_reduction": 0,
@@ -637,7 +639,7 @@
 				"tower_stat": true
 			},
 			"next": [],
-			"price": 0,
+			"price": 175,
 			"tower_stats": {
 				"fire_rate": 0,
 				"level": 1,
@@ -655,7 +657,7 @@
 				"chain_bounces": 0,
 				"chain_damage_falloff": 0,
 				"chain_range": 0,
-				"damage": 4,
+				"damage": 1,
 				"damage_multiplier": 0,
 				"electrify_duration": 0,
 				"electrify_slow_amount": 0,
@@ -676,7 +678,7 @@
 			"next": [
 				"bat_08_03"
 			],
-			"price": 0,
+			"price": 100,
 			"tower_stats": {
 				"fire_rate": 0,
 				"level": 1,
@@ -689,13 +691,13 @@
 		"bat_08_03": {
 			"bullet_stats": {
 				"aoe_duration": 0,
-				"aoe_range": 0,
+				"aoe_range": 15,
 				"burn_damage_base": 0,
 				"burn_duration": 0,
 				"chain_bounces": 0,
 				"chain_damage_falloff": 0,
 				"chain_range": 0,
-				"damage": 4,
+				"damage": 1.5,
 				"damage_multiplier": 0,
 				"electrify_duration": 0,
 				"electrify_slow_amount": 0,
@@ -717,7 +719,7 @@
 				"bat_08_a_04",
 				"bat_08_b_04"
 			],
-			"price": 0,
+			"price": 125,
 			"tower_stats": {
 				"fire_rate": 0,
 				"level": 1,
@@ -736,7 +738,7 @@
 				"chain_bounces": 2,
 				"chain_damage_falloff": 0.25,
 				"chain_range": 95,
-				"damage": -2,
+				"damage": 2,
 				"damage_multiplier": 0,
 				"electrify_duration": 0,
 				"electrify_slow_amount": 0,
@@ -757,7 +759,7 @@
 			"next": [
 				"bat_08_a_05"
 			],
-			"price": 0,
+			"price": 200,
 			"tower_stats": {
 				"fire_rate": 0,
 				"level": 1,
@@ -776,7 +778,7 @@
 				"chain_bounces": 1,
 				"chain_damage_falloff": 0.15,
 				"chain_range": 25,
-				"damage": 2,
+				"damage": 1.5,
 				"damage_multiplier": 0,
 				"electrify_duration": 0,
 				"electrify_slow_amount": 0,
@@ -795,7 +797,7 @@
 				"tower_stat": true
 			},
 			"next": [],
-			"price": 0,
+			"price": 175,
 			"tower_stats": {
 				"fire_rate": 0,
 				"level": 1,
@@ -814,7 +816,7 @@
 				"chain_bounces": 0,
 				"chain_damage_falloff": 0,
 				"chain_range": 0,
-				"damage": -4,
+				"damage": 1,
 				"damage_multiplier": 0,
 				"electrify_duration": 2.5,
 				"electrify_slow_amount": 0.18,
@@ -835,9 +837,9 @@
 			"next": [
 				"bat_08_b_05"
 			],
-			"price": 0,
+			"price": 200,
 			"tower_stats": {
-				"fire_rate": -0.6,
+				"fire_rate": -1,
 				"level": 1,
 				"prefer_non_electrified_targets": true,
 				"projectile_count": 0,
@@ -854,7 +856,7 @@
 				"chain_bounces": 0,
 				"chain_damage_falloff": 0,
 				"chain_range": 0,
-				"damage": 0,
+				"damage": 0.5,
 				"damage_multiplier": 0,
 				"electrify_duration": 1,
 				"electrify_slow_amount": 0.07,
@@ -873,9 +875,9 @@
 				"tower_stat": true
 			},
 			"next": [],
-			"price": 0,
+			"price": 175,
 			"tower_stats": {
-				"fire_rate": -0.4,
+				"fire_rate": -0.5,
 				"level": 1,
 				"prefer_non_electrified_targets": true,
 				"projectile_count": 0,


### PR DESCRIPTION
## Summary
First global balancing pass across all entity stats in \`stats.json\`. Prior to this PR, most values were placeholder numbers from initial setup: enemies died in one hit, towers were either absurdly overpowered or comically cheap, and all upgrade prices were hardcoded to 0 (free). This pass establishes a coherent baseline difficulty curve and a real economy where tower cost, range, damage, and fire rate are proportional to their role.

## Key Changes

### Enemies

All enemy health values were unrealistically low — a single shot from any tower killed most enemies, making waves trivial. Health values have been scaled up significantly to force towers to actually work together over multiple hits. Reward values have also been rebalanced to reflect strategic value, not just raw health.

- **`default_zombie`** — health 20→100, reward 10→20. Was dying in a single hit from the weakest tower. Now requires a few shots, giving the player time to react to waves.
- **`damage_zombie`** — health 100→200, reward 10→40, speed 30→25. The tankiest basic enemy now actually feels durable. Slight speed nerf makes it a sustained pressure threat rather than a fast rusher.
- **`rat`** — health 10→25, reward 10→2, speed 100→75. Rats were a gold exploit: fast, easy to kill, and rewarding the same as harder enemies. Reward slashed to 2 to make them a nuisance rather than a farming target. Speed reduced to keep them threatening but not absurd.
- **`splitter_zombie`** — health 80→150, reward 20→5. The danger of this enemy is the split mechanic — the high reward was making it accidentally profitable to let them through. Reward now reflects that it's a complex threat, not a bounty.
- **`small_zombie`** — health 10→25, reward 5→10, speed 70→75. Minor buff across the board; small zombies should feel slightly more dangerous as filler enemies.
- **`big_daddy`** — reward 10→500, speed 20→35. Boss reward was identical to a basic zombie (10 gold) — completely wrong. Now killing the big_daddy is a meaningful economic event. Speed bump makes it slightly more aggressive and less of a static tank.

### Towers

Tower base stats were wildly inconsistent. bat_01 had 100 damage and a huge range, one-shotting every non-boss enemy. Costs didn't reflect power levels at all. The goal here is to make each tower feel distinct in role (DPS, AoE control, utility, trap) with appropriate tradeoffs.

- **`bat_01` (basic archer)** — damage 100→25, fire_rate 1.5→1.0, shoot_range 100→55. Was a win-button: one-shot any standard enemy at long range. Now it's a reliable single-target DPS tower that requires multiple hits and careful positioning.
- **`bat_02` (inferno / AoE)** — aoe_range 100→15, cost 50→100, fire_rate 1.5→0.5, shoot_range 150→35. The AoE radius of 100 was covering the entire map. Tightened to 15 so placement near chokepoints is the actual skill expression. Fire rate halved and cost doubled to match its now-precision role.
- **`bat_08` (tesla / electricity)** — damage 18→1.5, cost 25→150, fire_rate 2→5. Previously a cheap instakill. Repositioned as a fast-firing, low-damage crowd controller — the value comes from electrify/chain effects on upgrades, not raw damage. Cost raised to 150 to reflect its utility ceiling.
- **`bat_09` (trap)** — cost 10→200. Was essentially free. Traps are passive area-denial tools with no maintenance cost — 200 gold is appropriate for a set-and-forget utility.

### Upgrades

Every upgrade price was 0, meaning upgrades were free and the upgrade tree had no economic weight. Prices are now tiered by depth (tier 2: ~100g, tier 3: ~125g, tier 4: ~150–175g, tier 5: ~175–200g). Damage and stat delta values have also been adjusted to stay proportional to the new base stats.

- **bat_01 upgrade tree** — damage deltas corrected throughout (some were negative or near-zero). Pierce count on mid-tier upgrades adjusted to 1→2 to feel like a meaningful unlock. `dot_damage` field added to some bullet stats for future DoT integration.
- **bat_02 upgrade tree** — fire_rate and aoe_range deltas corrected. burn_damage_base and burn_duration now properly stack across tiers. aoe_range delta tightened (−20→−5, +20→+15) to avoid going back to the pre-nerf radius.
- **bat_08 upgrade tree** — chain path (bat_08_a) had a negative damage delta (−2) which was a bug; corrected to +2. Electrify path (bat_08_b) fire_rate modifiers adjusted (−0.6→−1.0 at tier 4, −0.4→−0.5 at tier 5) to make the slow-but-powerful electrifier fantasy clearer. aoe_range added to bat_08_03 (0→15) to give the base tesla a small splash.
- **bat_09 upgrade tree** — tier-2 and tier-3 damage bumped (0.1→0.2 / 0.1→0.3) since 0.1 damage per upgrade was imperceptible on a trap.

## Test Plan
- [ ] Early waves (1–2): default and small zombies survive more than one bat_01 shot.
- [ ] Rat kills yield 2 gold, not 10.
- [ ] big_daddy drops 500 gold on death.
- [ ] bat_02 AoE radius visually covers a tight area — enemies outside a chokepoint are not hit.
- [ ] Purchasing upgrades deducts correct gold (non-zero prices).
- [ ] bat_08 chain upgrade deals positive damage and correctly bounces to nearby enemies.
- [ ] bat_08 electrify upgrade applies slow without negative damage interaction.
- [ ] Full run on at least one level — gold income feels proportional to wave difficulty.
- [ ] No tower can one-shot a default_zombie at base level.